### PR TITLE
[Fix] Bug fixes in data converters and transforms

### DIFF
--- a/docs/preprocess_dataset.md
+++ b/docs/preprocess_dataset.md
@@ -362,6 +362,31 @@ mmhuman3d
                    └── ...
 ```
 
+### AMASS
+
+<!-- [DATASET] -->
+
+<details>
+<summary align="right"><a href="https://files.is.tue.mpg.de/black/papers/amass.pdf">AMASS (ICCV'2019)</a></summary>
+
+```bibtex
+@inproceedings{AMASS:2019,
+  title={AMASS: Archive of Motion Capture as Surface Shapes},
+  author={Mahmood, Naureen and Ghorbani, Nima and F. Troje, Nikolaus and Pons-Moll, Gerard and Black, Michael J.},
+  booktitle = {The IEEE International Conference on Computer Vision (ICCV)},
+  year={2019},
+  month = {Oct},
+  url = {https://amass.is.tue.mpg.de},
+  month_numeric = {10}
+}
+```
+
+Details for direct preprocessing will be added in the future.
+
+**Alternatively**, you may download the preprocessed files directly:
+- [amass_smplh.npz](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/datasets/amass_smplh.npz?versionId=CAEQIhiBgICS4Mrt7xciIGU5MDBmZmE4Y2I0NjRiYTc4ZWY2NzY2MzU1ZmIwZTQ2)
+- [amass_smplx.npz](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/datasets/amass_smplx.npz?versionId=CAEQIhiBgIDh387t7xciIGRlN2JlZjA0ZGM0YzRkNmM5OWJhNmVjMmZlN2RiN2E1)
+
 ### COCO
 
 <!-- [DATASET] -->

--- a/mmhuman3d/data/data_converters/agora.py
+++ b/mmhuman3d/data/data_converters/agora.py
@@ -170,7 +170,8 @@ class AgoraConverter(BaseModeConverter):
                         max(keypoints2d[:, 0]),
                         max(keypoints2d[:, 1])
                     ]
-                    bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                    bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                    bbox_xywh = self._xyxy2xywh(bbox_xyxy)
 
                     keypoints2d_.append(keypoints2d)
                     keypoints3d_.append(keypoints3d)

--- a/mmhuman3d/data/data_converters/agora.py
+++ b/mmhuman3d/data/data_converters/agora.py
@@ -118,7 +118,7 @@ class AgoraConverter(BaseModeConverter):
 
                     # obtain keypoints
                     keypoints2d = df.iloc[idx]['gt_joints_2d'][pidx]
-                    if self.res == '1280x720':
+                    if self.res == (1280, 720):
                         keypoints2d *= (720 / 2160)
                     keypoints3d = df.iloc[idx]['gt_joints_3d'][pidx]
 

--- a/mmhuman3d/data/data_converters/agora.py
+++ b/mmhuman3d/data/data_converters/agora.py
@@ -105,7 +105,7 @@ class AgoraConverter(BaseModeConverter):
             for idx in tqdm(range(len(df))):
                 imgname = df.iloc[idx]['imgPath']
                 if self.res == (1280, 720):
-                    imgname.replace('.png', '_1280x720.png')
+                    imgname = imgname.replace('.png', '_1280x720.png')
                 img_path = os.path.join('images', mode, imgname)
                 valid_pers_idx = np.where(df.iloc[idx].at['isValid'])[0]
                 for pidx in valid_pers_idx:

--- a/mmhuman3d/data/data_converters/base_converter.py
+++ b/mmhuman3d/data/data_converters/base_converter.py
@@ -26,13 +26,13 @@ class BaseConverter(metaclass=ABCMeta):
     @staticmethod
     def _bbox_expand(bbox_xyxy: List[float],
                      scale_factor: float) -> List[float]:
-        """Obtain bbox in xywh format given bbox in xyxy format
+        """Expand bbox in xyxy format by scale factor
         Args:
             bbox_xyxy (List[float]): Bounding box in xyxy format
             scale_factor (float): Scale factor to expand bbox
 
         Returns:
-            bbox_xywh (List[float]): Bounding box in xywh format
+            bbox_xyxy (List[float]): Expanded bounding box in xyxy format
         """
         center = [(bbox_xyxy[0] + bbox_xyxy[2]) / 2,
                   (bbox_xyxy[1] + bbox_xyxy[3]) / 2]
@@ -40,6 +40,18 @@ class BaseConverter(metaclass=ABCMeta):
         y1 = scale_factor * (bbox_xyxy[1] - center[1]) + center[1]
         x2 = scale_factor * (bbox_xyxy[2] - center[0]) + center[0]
         y2 = scale_factor * (bbox_xyxy[3] - center[1]) + center[1]
+        return [x1, y1, x2, y2]
+
+    @staticmethod
+    def _xyxy2xywh(bbox_xyxy: List[float]) -> List[float]:
+        """Obtain bbox in xywh format given bbox in xyxy format
+        Args:
+            bbox_xyxy (List[float]): Bounding box in xyxy format
+
+        Returns:
+            bbox_xywh (List[float]): Bounding box in xywh format
+        """
+        x1, y1, x2, y2 = bbox_xyxy
         return [x1, y1, x2 - x1, y2 - y1]
 
 

--- a/mmhuman3d/data/data_converters/h36m.py
+++ b/mmhuman3d/data/data_converters/h36m.py
@@ -372,7 +372,8 @@ class H36mConverter(BaseModeConverter):
 
         metadata_path = os.path.join(dataset_path, 'metadata.xml')
         if isinstance(metadata_path, str):
-            cam_param = H36mCamera(metadata_path)
+            camera = H36mCamera(metadata_path)
+            cam_param = camera.generate_cameras_dict()
         bbox_xywh_ = np.array(bbox_xywh_).reshape((-1, 4))
         bbox_xywh_ = np.hstack([bbox_xywh_, np.ones([bbox_xywh_.shape[0], 1])])
         keypoints2d_ = np.array(keypoints2d_).reshape((-1, 17, 3))

--- a/mmhuman3d/data/data_converters/h36m.py
+++ b/mmhuman3d/data/data_converters/h36m.py
@@ -327,8 +327,9 @@ class H36mConverter(BaseModeConverter):
                             np.max(xs) + 1,
                             np.max(ys) + 1
                         ])
-                        bbox_xywh = self._bbox_expand(
+                        bbox_xyxy = self._bbox_expand(
                             bbox_xyxy, scale_factor=0.9)
+                        bbox_xywh = self._xyxy2xywh(bbox_xyxy)
 
                         # read GT 2D pose
                         keypoints2dall = np.reshape(poses_2d[frame_i, :],

--- a/mmhuman3d/data/data_converters/h36m_spin.py
+++ b/mmhuman3d/data/data_converters/h36m_spin.py
@@ -191,7 +191,9 @@ class H36mSpinConverter(BaseModeConverter):
                             np.max(xs) + 1,
                             np.max(ys) + 1
                         ])
-                        bbox = self._bbox_expand(bbox_xyxy, scale_factor=0.9)
+                        bbox_xyxy = self._bbox_expand(
+                            bbox_xyxy, scale_factor=1.2)
+                        bbox = self._xyxy2xywh(bbox_xyxy)
 
                         # read GT 2D pose
                         keypoints2dall = np.reshape(poses_2d[frame_i, :],

--- a/mmhuman3d/data/data_converters/h36m_spin.py
+++ b/mmhuman3d/data/data_converters/h36m_spin.py
@@ -192,7 +192,7 @@ class H36mSpinConverter(BaseModeConverter):
                             np.max(ys) + 1
                         ])
                         bbox_xyxy = self._bbox_expand(
-                            bbox_xyxy, scale_factor=1.2)
+                            bbox_xyxy, scale_factor=0.9)
                         bbox = self._xyxy2xywh(bbox_xyxy)
 
                         # read GT 2D pose

--- a/mmhuman3d/data/data_converters/humman.py
+++ b/mmhuman3d/data/data_converters/humman.py
@@ -206,7 +206,8 @@ class HuMManConverter(BaseModeConverter):
 
                 for xmin, xmax, ymin, ymax in zip(xmins, xmaxs, ymins, ymaxs):
                     bbox_xyxy = [xmin, ymin, xmax, ymax]
-                    bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                    bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                    bbox_xywh = self._xyxy2xywh(bbox_xyxy)
                     bbox_xywh_.append(bbox_xywh)
 
                 # get keypoints3d (all frames)

--- a/mmhuman3d/data/data_converters/insta_vibe.py
+++ b/mmhuman3d/data/data_converters/insta_vibe.py
@@ -63,7 +63,8 @@ class InstaVibeConverter(BaseConverter):
                 max(keypoints2d_vis[:, 0]),
                 max(keypoints2d_vis[:, 1])
             ]
-            bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+            bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+            bbox_xywh = self._xyxy2xywh(bbox_xyxy)
 
             vid_path_.append(vid_id)
             image_path_.append(image_path)

--- a/mmhuman3d/data/data_converters/lsp.py
+++ b/mmhuman3d/data/data_converters/lsp.py
@@ -72,16 +72,16 @@ class LspConverter(BaseModeConverter):
             keypoints2d14 = np.hstack([keypoints2d14, np.ones([14, 1])])
 
             # bbox
-            bbox_xywh = [
+            bbox_xyxy = [
                 min(keypoints2d14[:, 0]),
                 min(keypoints2d14[:, 1]),
                 max(keypoints2d14[:, 0]),
                 max(keypoints2d14[:, 1])
             ]
 
-            if 0 <= bbox_xywh[0] <= w and 0 <= bbox_xywh[2] <= w and \
-                    0 <= bbox_xywh[1] <= h and 0 <= bbox_xywh[3] <= h:
-                bbox_xywh = self._bbox_expand(bbox_xywh, scale_factor=1.2)
+            if 0 <= bbox_xyxy[0] <= w and 0 <= bbox_xyxy[2] <= w and \
+                    0 <= bbox_xyxy[1] <= h and 0 <= bbox_xyxy[3] <= h:
+                bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
             else:
                 print('Bbox out of image bounds. Skipping image {}'.format(
                     imgname))

--- a/mmhuman3d/data/data_converters/lsp.py
+++ b/mmhuman3d/data/data_converters/lsp.py
@@ -81,7 +81,8 @@ class LspConverter(BaseModeConverter):
 
             if 0 <= bbox_xyxy[0] <= w and 0 <= bbox_xyxy[2] <= w and \
                     0 <= bbox_xyxy[1] <= h and 0 <= bbox_xyxy[3] <= h:
-                bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                bbox_xywh = self._xyxy2xywh(bbox_xyxy)
             else:
                 print('Bbox out of image bounds. Skipping image {}'.format(
                     imgname))

--- a/mmhuman3d/data/data_converters/lsp_extended.py
+++ b/mmhuman3d/data/data_converters/lsp_extended.py
@@ -69,7 +69,8 @@ class LspExtendedConverter(BaseConverter):
 
             if 0 <= bbox_xyxy[0] <= w and 0 <= bbox_xyxy[2] <= w and \
                     0 <= bbox_xyxy[1] <= h and 0 <= bbox_xyxy[3] <= h:
-                bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                bbox_xywh = self._xyxy2xywh(bbox_xyxy)
             else:
                 print('Bbox out of image bounds. Skipping image {}'.format(
                     imgname))

--- a/mmhuman3d/data/data_converters/lsp_extended.py
+++ b/mmhuman3d/data/data_converters/lsp_extended.py
@@ -60,16 +60,16 @@ class LspExtendedConverter(BaseConverter):
             keypoints2d14 = np.hstack([keypoints2d14, np.ones([14, 1])])
 
             # bbox
-            bbox_xywh = [
+            bbox_xyxy = [
                 min(keypoints2d14[:, 0]),
                 min(keypoints2d14[:, 1]),
                 max(keypoints2d14[:, 0]),
                 max(keypoints2d14[:, 1])
             ]
 
-            if 0 <= bbox_xywh[0] <= w and 0 <= bbox_xywh[2] <= w and \
-                    0 <= bbox_xywh[1] <= h and 0 <= bbox_xywh[3] <= h:
-                bbox_xywh = self._bbox_expand(bbox_xywh, scale_factor=1.2)
+            if 0 <= bbox_xyxy[0] <= w and 0 <= bbox_xyxy[2] <= w and \
+                    0 <= bbox_xyxy[1] <= h and 0 <= bbox_xyxy[3] <= h:
+                bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
             else:
                 print('Bbox out of image bounds. Skipping image {}'.format(
                     imgname))

--- a/mmhuman3d/data/data_converters/mpi_inf_3dhp.py
+++ b/mmhuman3d/data/data_converters/mpi_inf_3dhp.py
@@ -45,7 +45,8 @@ class MpiInf3dhpConverter(BaseModeConverter):
             max(keypoints2d[:, 0]),
             max(keypoints2d[:, 1])
         ]
-        bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+        bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+        bbox_xywh = self._xyxy2xywh(bbox_xyxy)
 
         # check that all joints are visible
         h, w = 2048, 2048

--- a/mmhuman3d/data/data_converters/penn_action.py
+++ b/mmhuman3d/data/data_converters/penn_action.py
@@ -75,7 +75,8 @@ class PennActionConverter(BaseConverter):
                     max(kp[:, 0]),
                     max(kp[:, 1])
                 ]
-                bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                bbox_xywh = self._xyxy2xywh(bbox_xyxy)
                 # store relative instead of absolute image path
                 image_path_.append(img_path.replace(dataset_path + '/', ''))
                 bbox_xywh_.append(bbox_xywh)

--- a/mmhuman3d/data/data_converters/posetrack.py
+++ b/mmhuman3d/data/data_converters/posetrack.py
@@ -49,23 +49,24 @@ class PosetrackConverter(BaseModeConverter):
         for ann_file in tqdm(ann_files):
             json_data = mmcv.load(ann_file)
 
-            counter = 0
-            for im, ann in zip(json_data['images'], json_data['annotations']):
-                # sample every 10 image and check image is labelled
-                if counter % 10 != 0 and not im['is_labeled']:
-                    continue
+            imgs = {}
+            for img in json_data['images']:
+                imgs[img['id']] = img
+
+            for ann in json_data['annotations']:
+                image_id = ann['image_id']
+                image_path = str(imgs[image_id]['file_name'])
+
                 keypoints2d = np.array(ann['keypoints']).reshape(17, 3)
                 keypoints2d[keypoints2d[:, 2] > 0, 2] = 1
                 # check if all major body joints are annotated
                 if sum(keypoints2d[5:, 2] > 0) < 12:
                     continue
 
-                image_path = im['file_name']
                 image_abs_path = os.path.join(dataset_path, image_path)
                 if not os.path.exists(image_abs_path):
                     print('{} does not exist!'.format(image_abs_path))
                     continue
-                counter += 1
                 bbox_xywh = np.array(ann['bbox'])
 
                 # store data

--- a/mmhuman3d/data/data_converters/pw3d.py
+++ b/mmhuman3d/data/data_converters/pw3d.py
@@ -53,7 +53,6 @@ class Pw3dConverter(BaseModeConverter):
         smpl['body_pose'] = []
         smpl['global_orient'] = []
         smpl['betas'] = []
-        smpl['transl'] = []
         meta = {}
         meta['gender'] = []
 
@@ -79,7 +78,6 @@ class Pw3dConverter(BaseModeConverter):
                 num_people = len(smpl_pose)
                 num_frames = len(smpl_pose[0])
                 seq_name = str(data['sequence'])
-                trans = data['trans']
                 img_names = np.array([
                     'imageFiles/' + seq_name + f'/image_{str(i).zfill(5)}.jpg'
                     for i in range(num_frames)
@@ -94,7 +92,6 @@ class Pw3dConverter(BaseModeConverter):
                     valid_img_names = img_names[valid[i]]
                     valid_global_poses = global_poses[valid[i]]
                     gender = genders[i]
-                    t_s = trans[i]
 
                     # consider only valid frames
                     for valid_i in range(valid_pose.shape[0]):
@@ -133,7 +130,6 @@ class Pw3dConverter(BaseModeConverter):
                         smpl['body_pose'].append(pose[3:].reshape((23, 3)))
                         smpl['global_orient'].append(pose[:3])
                         smpl['betas'].append(valid_betas[valid_i])
-                        smpl['transl'].append(t_s[valid_i])
                         meta['gender'].append(gender)
                         cam_param_.append(parameter_dict)
 

--- a/mmhuman3d/data/data_converters/pw3d.py
+++ b/mmhuman3d/data/data_converters/pw3d.py
@@ -97,7 +97,7 @@ class Pw3dConverter(BaseModeConverter):
                     for valid_i in range(valid_pose.shape[0]):
                         keypoints2d = valid_keypoints_2d[valid_i, :, :].T
                         keypoints2d = keypoints2d[keypoints2d[:, 2] > 0, :]
-                        bbox_xywh = [
+                        bbox_xyxy = [
                             min(keypoints2d[:, 0]),
                             min(keypoints2d[:, 1]),
                             max(keypoints2d[:, 0]),
@@ -105,7 +105,7 @@ class Pw3dConverter(BaseModeConverter):
                         ]
 
                         bbox_xywh = self._bbox_expand(
-                            bbox_xywh, scale_factor=1.2)
+                            bbox_xyxy, scale_factor=1.2)
 
                         image_path = valid_img_names[valid_i]
                         image_abs_path = os.path.join(root_path, image_path)

--- a/mmhuman3d/data/data_converters/pw3d.py
+++ b/mmhuman3d/data/data_converters/pw3d.py
@@ -104,8 +104,9 @@ class Pw3dConverter(BaseModeConverter):
                             max(keypoints2d[:, 1])
                         ]
 
-                        bbox_xywh = self._bbox_expand(
+                        bbox_xyxy = self._bbox_expand(
                             bbox_xyxy, scale_factor=1.2)
+                        bbox_xywh = self._xyxy2xywh(bbox_xyxy)
 
                         image_path = valid_img_names[valid_i]
                         image_abs_path = os.path.join(root_path, image_path)

--- a/mmhuman3d/data/data_converters/pw3d.py
+++ b/mmhuman3d/data/data_converters/pw3d.py
@@ -53,6 +53,7 @@ class Pw3dConverter(BaseModeConverter):
         smpl['body_pose'] = []
         smpl['global_orient'] = []
         smpl['betas'] = []
+        smpl['transl'] = []
         meta = {}
         meta['gender'] = []
 
@@ -78,6 +79,7 @@ class Pw3dConverter(BaseModeConverter):
                 num_people = len(smpl_pose)
                 num_frames = len(smpl_pose[0])
                 seq_name = str(data['sequence'])
+                trans = data['trans']
                 img_names = np.array([
                     'imageFiles/' + seq_name + f'/image_{str(i).zfill(5)}.jpg'
                     for i in range(num_frames)
@@ -92,6 +94,7 @@ class Pw3dConverter(BaseModeConverter):
                     valid_img_names = img_names[valid[i]]
                     valid_global_poses = global_poses[valid[i]]
                     gender = genders[i]
+                    t_s = trans[i]
 
                     # consider only valid frames
                     for valid_i in range(valid_pose.shape[0]):
@@ -130,6 +133,7 @@ class Pw3dConverter(BaseModeConverter):
                         smpl['body_pose'].append(pose[3:].reshape((23, 3)))
                         smpl['global_orient'].append(pose[:3])
                         smpl['betas'].append(valid_betas[valid_i])
+                        smpl['transl'].append(t_s[valid_i])
                         meta['gender'].append(gender)
                         cam_param_.append(parameter_dict)
 

--- a/mmhuman3d/data/data_converters/surreal.py
+++ b/mmhuman3d/data/data_converters/surreal.py
@@ -184,10 +184,10 @@ class SurrealConverter(BaseModeConverter):
                         success, image = vidcap.read()
                         if not success:
                             break
-                        frame += 1
                         # image name
                         imgname = os.path.join(img_dir,
                                                'frame_%06d.jpg' % frame)
+                        frame += 1
                         # save image
                         cv2.imwrite(imgname, image)
 

--- a/mmhuman3d/data/data_converters/surreal.py
+++ b/mmhuman3d/data/data_converters/surreal.py
@@ -202,7 +202,8 @@ class SurrealConverter(BaseModeConverter):
                         max(keypoints2d[:, 0]),
                         max(keypoints2d[:, 1])
                     ]
-                    bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                    bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=1.2)
+                    bbox_xywh = self._xyxy2xywh(bbox_xyxy)
 
                     # add confidence column
                     keypoints2d = np.hstack([keypoints2d, np.ones((24, 1))])

--- a/mmhuman3d/data/data_converters/up3d.py
+++ b/mmhuman3d/data/data_converters/up3d.py
@@ -83,7 +83,8 @@ class Up3dConverter(BaseModeConverter):
                  np.min(ys),
                  np.max(xs) + 1,
                  np.max(ys) + 1])
-            bbox_xywh = self._bbox_expand(bbox_xyxy, scale_factor=0.9)
+            bbox_xyxy = self._bbox_expand(bbox_xyxy, scale_factor=0.9)
+            bbox_xywh = self._xyxy2xywh(bbox_xyxy)
 
             # pose and shape
             pkl_file = os.path.join(dataset_path, '%s_body.pkl' % img_base)

--- a/mmhuman3d/data/datasets/pipelines/transforms.py
+++ b/mmhuman3d/data/datasets/pipelines/transforms.py
@@ -339,14 +339,14 @@ class RandomHorizontalFlip(object):
         # flip keypoints3d
         if 'keypoints3d' in results:
             assert self.flip_pairs is not None
-            keypoints3d = results['keypoints3d']
+            keypoints3d = results['keypoints3d'].copy()
             keypoints3d = _flip_keypoints(keypoints3d, self.flip_pairs)
             results['keypoints3d'] = keypoints3d
 
         # flip smpl
         if 'smpl_body_pose' in results:
-            global_orient = results['smpl_global_orient']
-            body_pose = results['smpl_body_pose'].reshape((-1))
+            global_orient = results['smpl_global_orient'].copy()
+            body_pose = results['smpl_body_pose'].copy().reshape((-1))
             smpl_pose = np.concatenate((global_orient, body_pose), axis=-1)
             smpl_pose_flipped = _flip_smpl_pose(smpl_pose)
             global_orient = smpl_pose_flipped[:3]
@@ -696,13 +696,13 @@ class MeshAffine:
             results['keypoints2d'] = keypoints2d
 
         if 'keypoints3d' in results:
-            keypoints3d = results['keypoints3d']
+            keypoints3d = results['keypoints3d'].copy()
             keypoints3d[:, :3] = _rotate_joints_3d(keypoints3d[:, :3], r)
             results['keypoints3d'] = keypoints3d
 
         if 'smpl_body_pose' in results:
-            global_orient = results['smpl_global_orient']
-            body_pose = results['smpl_body_pose'].reshape((-1))
+            global_orient = results['smpl_global_orient'].copy()
+            body_pose = results['smpl_body_pose'].copy().reshape((-1))
             pose = np.concatenate((global_orient, body_pose), axis=-1)
             pose = _rotate_smpl_pose(pose, r)
             results['global_orient'] = pose[:3]

--- a/mmhuman3d/data/datasets/pipelines/transforms.py
+++ b/mmhuman3d/data/datasets/pipelines/transforms.py
@@ -327,7 +327,7 @@ class RandomHorizontalFlip(object):
         if 'keypoints2d' in results:
             assert self.flip_pairs is not None
             width = results['img'][:, ::-1, :].shape[1]
-            keypoints2d = results['keypoints2d']
+            keypoints2d = results['keypoints2d'].copy()
             keypoints2d = _flip_keypoints(keypoints2d, self.flip_pairs, width)
             results['keypoints2d'] = keypoints2d
 
@@ -687,7 +687,7 @@ class MeshAffine:
             results['img'] = img
 
         if 'keypoints2d' in results:
-            keypoints2d = results['keypoints2d']
+            keypoints2d = results['keypoints2d'].copy()
             num_keypoints = len(keypoints2d)
             for i in range(num_keypoints):
                 if keypoints2d[i][2] > 0.0:


### PR DESCRIPTION
Resolves #67 

- Inplace renaming operation to obtain correct image path in agora converter
- Use tuple instead of string check in agora converter
- Retrieve correct image path using id in posetrack converter
- Fix inconsistency is cv2.inwrite image path and stored image path in surreal converter
- Fix H36M cam_param to store a dictionary of camera parameters

Resolves #70 
- Fix type in instances where `bbox_xywh` is `bbox_xyxy`
- Split `_bbox_expand` to `bbox_expand` (only bbox expansion) and `xyxy2xywh` (xyxy conversion to xywh)

Resolves #79 issue of `keypoints2d_loss` not converging
- Make a copy of keypoints2d instead of directly modifying when applying augmentations