### PR TITLE
[Feature] Accept numpy and torch in CameraParameter

### DIFF
--- a/mmhuman3d/core/cameras/camera_parameters.py
+++ b/mmhuman3d/core/cameras/camera_parameters.py
@@ -539,7 +539,6 @@ class CameraParameter:
             if validation_result == _TypeValidation.ARRAY:
                 err_msg += 'A single value is expected, ' +\
                     'neither an array nor a slice.\n'
-            print(err_msg)
             raise TypeError(err_msg)
         return ret_val
 

--- a/mmhuman3d/core/cameras/camera_parameters.py
+++ b/mmhuman3d/core/cameras/camera_parameters.py
@@ -453,7 +453,7 @@ class CameraParameter:
             val (Any): The value casted into correct format.
         """
         self.__check_key__(key)
-        formatted_val = self.__check_value_type__(key, val)
+        formatted_val = self.__validate_value_type__(key, val)
         return key, formatted_val
 
     def __check_key__(self, key: Any) -> None:
@@ -474,7 +474,7 @@ class CameraParameter:
             err_msg += f'key={str(key)}\n'
             raise KeyError(err_msg)
 
-    def __check_value_type__(self, key: Any, val: Any) -> None:
+    def __validate_value_type__(self, key: Any, val: Any) -> None:
         """Check whether the type of value matches definition in
         CameraParameter.SUPPORTED_KEYS.
 
@@ -501,7 +501,7 @@ class CameraParameter:
             if type(val) == self.__class__.SUPPORTED_KEYS[key]['type']:
                 check_passed = True
                 ret_val = val
-            if 'numpy' in type_str:
+            elif 'numpy' in type_str:
                 # a value is required, not array
                 if np.issubdtype(
                         type(val),

--- a/mmhuman3d/core/cameras/camera_parameters.py
+++ b/mmhuman3d/core/cameras/camera_parameters.py
@@ -82,9 +82,9 @@ class CameraParameter:
         self.parameters_dict['in_mat'] = in_mat
         for distort_name in __distort_coefficient_names__:
             self.parameters_dict[distort_name] = 0.0
-        _, H = self.check_item('H', H)
+        _, H = self.validate_item('H', H)
         self.parameters_dict['H'] = H
-        _, W = self.check_item('W', W)
+        _, W = self.validate_item('W', W)
         self.parameters_dict['W'] = W
         r_mat = __zero_mat_list__(3)
         self.parameters_dict['rotation_mat'] = r_mat
@@ -211,7 +211,7 @@ class CameraParameter:
             mat_list (List[list]):
                 Matrix in list format.
         """
-        _, mat_list = self.check_item(mat_key, mat_list)
+        _, mat_list = self.validate_item(mat_key, mat_list)
         self.parameters_dict[mat_key] = mat_list
 
     def set_value(self, key: str, value: Any) -> None:
@@ -223,7 +223,7 @@ class CameraParameter:
             value (object):
                 New value of the parameter.
         """
-        _, value = self.check_item(key, value)
+        _, value = self.validate_item(key, value)
         self.parameters_dict[key] = value
 
     def get_value(self, key: str) -> Any:
@@ -432,7 +432,7 @@ class CameraParameter:
                 resolution=(height, width)))
         return cam
 
-    def check_item(self, key: Any, val: Any) -> None:
+    def validate_item(self, key: Any, val: Any) -> List:
         """Check whether the key and its value matches definition in
         CameraParameter.SUPPORTED_KEYS.
 
@@ -474,7 +474,7 @@ class CameraParameter:
             err_msg += f'key={str(key)}\n'
             raise KeyError(err_msg)
 
-    def __validate_value_type__(self, key: Any, val: Any) -> None:
+    def __validate_value_type__(self, key: Any, val: Any) -> Any:
         """Check whether the type of value matches definition in
         CameraParameter.SUPPORTED_KEYS.
 

--- a/tests/test_cameras/test_camera_parameter.py
+++ b/tests/test_cameras/test_camera_parameter.py
@@ -54,7 +54,7 @@ def test_load_json():
 
 def test_type():
     cam_param = CameraParameter(name='src_cam', H=720, W=1280)
-    # wrong distortion value type(expect float)
+    # wrong distortion value type (expect float)
     with pytest.raises(TypeError):
         cam_param.set_value('k1', '1.0')
     with pytest.raises(TypeError):
@@ -64,7 +64,7 @@ def test_type():
     cam_param.set_value('k1', torch.ones(size=(3, ), dtype=torch.float16)[0])
     cam_param.reset_distort()
 
-    # wrong height value type(expect float)
+    # wrong height value type (expect float)
     with pytest.raises(TypeError):
         cam_param.set_value('H', '1080')
     with pytest.raises(TypeError):

--- a/tests/test_cameras/test_camera_parameter.py
+++ b/tests/test_cameras/test_camera_parameter.py
@@ -3,6 +3,7 @@ import os
 
 import numpy as np
 import pytest
+import torch
 
 from mmhuman3d.core.cameras.camera_parameters import CameraParameter
 from mmhuman3d.utils.path_utils import Existence, check_path_existence
@@ -52,14 +53,27 @@ def test_load_json():
 
 
 def test_type():
-    cam_param = CameraParameter(name='src_cam')
-    # wrong distortion value type
+    cam_param = CameraParameter(name='src_cam', H=720, W=1280)
+    # wrong distortion value type(expect float)
     with pytest.raises(TypeError):
         cam_param.set_value('k1', '1.0')
     with pytest.raises(TypeError):
-        cam_param.set_value('k1', np.ones(shape=(3))[0])
+        cam_param.set_value('k1', np.ones(shape=(3, ), dtype=np.int8)[0])
     cam_param.set_value('k1', 1.0)
+    cam_param.set_value('k1', np.ones(shape=(3, ), dtype=np.float16)[0])
+    cam_param.set_value('k1', torch.ones(size=(3, ), dtype=torch.float16)[0])
     cam_param.reset_distort()
+
+    # wrong height value type(expect float)
+    with pytest.raises(TypeError):
+        cam_param.set_value('H', '1080')
+    with pytest.raises(TypeError):
+        cam_param.set_value('H', 1080.0)
+    with pytest.raises(TypeError):
+        cam_param.set_value('H', np.ones(shape=(3, ), dtype=np.float32)[0])
+    cam_param.set_value('H', np.ones(shape=(3, ), dtype=np.uint8)[0])
+    cam_param.set_value('H', torch.ones(size=(3, ), dtype=torch.int64)[0])
+    cam_param.set_value('H', 720)
 
     mat_3x3 = np.eye(3)
     # wrong mat type

--- a/tests/test_cameras/test_camera_parameter.py
+++ b/tests/test_cameras/test_camera_parameter.py
@@ -71,6 +71,14 @@ def test_type():
         cam_param.set_value('H', 1080.0)
     with pytest.raises(TypeError):
         cam_param.set_value('H', np.ones(shape=(3, ), dtype=np.float32)[0])
+    with pytest.raises(TypeError):
+        cam_param.set_value('H', np.ones(shape=(3, ), dtype=np.int64)[0:1])
+    with pytest.raises(TypeError):
+        cam_param.set_value('H',
+                            torch.ones(size=(3, ), dtype=torch.float32)[0])
+    with pytest.raises(TypeError):
+        cam_param.set_value('H',
+                            torch.ones(size=(3, ), dtype=torch.int32)[0:1])
     cam_param.set_value('H', np.ones(shape=(3, ), dtype=np.uint8)[0])
     cam_param.set_value('H', torch.ones(size=(3, ), dtype=torch.int64)[0])
     cam_param.set_value('H', 720)


### PR DESCRIPTION
As the former type check for CameraParameter is too strict, we increase the tolerance of CameraParameter.
In this PR, values of numpy type, torch type are supported, and casted into python scalar as well as the type is correct.   
For instance, a value `1080` in type `numpy.uint16` will be accepted and casted in to `int` automatically when setting value, but an array `[[1080,],]` with dtype==`numpy.uint16` will not.