### PR TITLE
[Dependency] Remove outdated requirements

### DIFF
--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,5 @@
 cdflib
+chumpy
 colormap
 easydev
 h5py

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,12 +1,9 @@
 cdflib
-chumpy
 colormap
-easydev
 h5py
 matplotlib
 numpy
 opencv-python
-pandas
 pickle5
 scikit-image
 scipy

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,5 +1,6 @@
 cdflib
 colormap
+easydev
 h5py
 matplotlib
 numpy


### PR DESCRIPTION
Some requirements seem to be outdated, to simplify installation, please help check whether the following packages are still required. 

According to [commit history](https://github.com/open-mmlab/mmhuman3d/blame/main/requirements/runtime.txt): 
- pandas (https://github.com/open-mmlab/mmhuman3d/commit/7893a7c2b65bca22544b497fcf2f369e17a5ab25) @pangyyyyy 