### PR TITLE
Upgrade HybrIK

### DIFF
--- a/configs/hybrik/README.md
+++ b/configs/hybrik/README.md
@@ -60,4 +60,4 @@ We evaluate HybrIK on 3DPW. Values are MPJPE/PA-MPJPE.
 
 | Config | 3DPW    | Download |
 |:------:|:-------:|:------:|
-| [resnet34_hybrik_mixed.py](resnet34_hybrik_mixed.py) | 86.92 / 50.30 | [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_pw3d-b2f87fa5_20211201.pth?versionId=CAEQHhiBgID_vYnS6xciIDAwZTk1MDJhNmM0ZDRlZmI5MTk3ZTAzNzJkOTIwZTc3) &#124; [log](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/20211109_164017.log?versionId=CAEQHhiBgICdvonS6xciIDdiNGYzY2Q3N2NiMTQ5MzdhOTZjYjEwZDM0ZjI3ODU1) |
+| [resnet34_hybrik_mixed.py](resnet34_hybrik_mixed.py) | 81.08 / 49.01 | [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_pw3d-b2f87fa5_20211201.pth?versionId=CAEQHhiBgID_vYnS6xciIDAwZTk1MDJhNmM0ZDRlZmI5MTk3ZTAzNzJkOTIwZTc3) &#124; [log](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/20211109_164017.log?versionId=CAEQHhiBgICdvonS6xciIDdiNGYzY2Q3N2NiMTQ5MzdhOTZjYjEwZDM0ZjI3ODU1) |

--- a/configs/hybrik/README.md
+++ b/configs/hybrik/README.md
@@ -60,4 +60,4 @@ We evaluate HybrIK on 3DPW. Values are MPJPE/PA-MPJPE.
 
 | Config | 3DPW    | Download |
 |:------:|:-------:|:------:|
-| [resnet34_hybrik_mixed.py](resnet34_hybrik_mixed.py) | 81.08 / 49.01 | [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_pw3d-b2f87fa5_20211201.pth?versionId=CAEQHhiBgID_vYnS6xciIDAwZTk1MDJhNmM0ZDRlZmI5MTk3ZTAzNzJkOTIwZTc3) &#124; [log](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/20211109_164017.log?versionId=CAEQHhiBgICdvonS6xciIDdiNGYzY2Q3N2NiMTQ5MzdhOTZjYjEwZDM0ZjI3ODU1) |
+| [resnet34_hybrik_mixed.py](resnet34_hybrik_mixed.py) | 81.08 / 49.02 | [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_mixed-a61b3c9c_20220211.pth?versionId=CAEQKhiBgMDx0.Kd9xciIDA2NWFlMGVmNjNkMDQyYzE4NTFmMGJiYjczZWZmM2Rk) &#124; [log](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/20220121_170847.log?versionId=CAEQKhiBgICMgOyb9xciIDZkMTMyODYzMDc4NjRhZTliOThiM2JlMDE1MzhhYTBm) |

--- a/configs/hybrik/metafile.yml
+++ b/configs/hybrik/metafile.yml
@@ -24,5 +24,5 @@ Models:
         Dataset: 3DPW
         Metrics:
           MPJPE: 81.08
-          PA-MPJPE: 49.01
-    Weights: https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_pw3d-b2f87fa5_20211201.pth?versionId=CAEQHhiBgID_vYnS6xciIDAwZTk1MDJhNmM0ZDRlZmI5MTk3ZTAzNzJkOTIwZTc3
+          PA-MPJPE: 49.02
+    Weights: https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_mixed-a61b3c9c_20220211.pth?versionId=CAEQKhiBgMDx0.Kd9xciIDA2NWFlMGVmNjNkMDQyYzE4NTFmMGJiYjczZWZmM2Rk

--- a/configs/hybrik/metafile.yml
+++ b/configs/hybrik/metafile.yml
@@ -23,6 +23,6 @@ Models:
       - Task: Human Pose and Shape Estimation
         Dataset: 3DPW
         Metrics:
-          MPJPE: 81.53
-          PA-MPJPE: 49.14
+          MPJPE: 81.08
+          PA-MPJPE: 49.01
     Weights: https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_pw3d-b2f87fa5_20211201.pth?versionId=CAEQHhiBgID_vYnS6xciIDAwZTk1MDJhNmM0ZDRlZmI5MTk3ZTAzNzJkOTIwZTc3

--- a/configs/hybrik/metafile.yml
+++ b/configs/hybrik/metafile.yml
@@ -23,6 +23,6 @@ Models:
       - Task: Human Pose and Shape Estimation
         Dataset: 3DPW
         Metrics:
-          MPJPE: 86.92
-          PA-MPJPE: 50.30
+          MPJPE: 81.53
+          PA-MPJPE: 49.14
     Weights: https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/hybrik/resnet34_hybrik_pw3d-b2f87fa5_20211201.pth?versionId=CAEQHhiBgID_vYnS6xciIDAwZTk1MDJhNmM0ZDRlZmI5MTk3ZTAzNzJkOTIwZTc3

--- a/mmhuman3d/models/architectures/hybrik.py
+++ b/mmhuman3d/models/architectures/hybrik.py
@@ -134,12 +134,7 @@ class HybrIK_trainer(BaseArchitecture, metaclass=ABCMeta):
 
         losses = self.compute_losses(predictions, labels)
 
-        loss, log_vars = self._parse_losses(losses)
-
-        output = {
-            'loss': loss,
-        }
-        return output
+        return losses
 
     def compute_losses(self, predictions, targets):
         """Compute regression losses for beta, theta, twist and uvd."""

--- a/mmhuman3d/models/utils/inverse_kinematics.py
+++ b/mmhuman3d/models/utils/inverse_kinematics.py
@@ -66,10 +66,14 @@ def batch_inverse_kinematics_transform(pose_skeleton,
     rel_pose_skeleton[:, 0] = rel_rest_pose[:, 0]
 
     # the predicted final pose
-    final_pose_skeleton = torch.unsqueeze(pose_skeleton.clone(), dim=-1)
-    final_pose_skeleton = final_pose_skeleton - \
-        final_pose_skeleton[:, 0:1] + rel_rest_pose[:, 0:1]
-
+    if train:
+        final_pose_skeleton = torch.unsqueeze(pose_skeleton.clone(), dim=-1)
+        final_pose_skeleton[:, 1:] -= final_pose_skeleton[:, parents[1:]].clone()
+        final_pose_skeleton[:,0] = rel_rest_pose[:,0]
+    else:
+        final_pose_skeleton = torch.unsqueeze(pose_skeleton.clone(), dim=-1)
+        final_pose_skeleton = final_pose_skeleton - \
+            final_pose_skeleton[:, 0:1] + rel_rest_pose[:, 0:1]        
     rel_rest_pose = rel_rest_pose
     rel_pose_skeleton = rel_pose_skeleton
     final_pose_skeleton = final_pose_skeleton
@@ -146,41 +150,46 @@ def batch_inverse_kinematics_transform(pose_skeleton,
                 torch.matmul(rot_mat_chain[parents[i]], rot_mat))
             rot_mat_local.append(rot_mat)
         else:
-            # (B, 3, 1)
-            rotate_rest_pose[:,
-                             i] = rotate_rest_pose[:,
-                                                   parents[i]] + torch.matmul(
-                                                       rot_mat_chain[
-                                                           parents[i]],
-                                                       rel_rest_pose[:, i])
-            # (B, 3, 1)
-            child_final_loc = final_pose_skeleton[:, children[
-                i]] - rotate_rest_pose[:, i]
+            # Naive Hybrik
+            if train:
+                # vec_t_k = t_k - t_pa(k)
+                # i: the index of k-th joint 
+                child_rest_loc = rel_rest_pose[:, i]
+                # p_k - p_pa(k)
+                child_final_loc = final_pose_skeleton[:,i]
 
+            # q_pa(k) = q_pa^2(k) + R_pa(k)(t_pa(k) - t_pa^2(k))
+            rotate_rest_pose[:, i] = rotate_rest_pose[:, parents[i]] + \
+                torch.matmul(rot_mat_chain[parents[i]], rel_rest_pose[:, i])
+            # Adaptive HybrIK
             if not train:
+                # vec_t_k = t_k - t_pa(k)
+                # children[i]: the index of k-th joint
+                child_rest_loc = rel_rest_pose[:, children[i]]
+
+                # p_k - q_pa(k)
+                child_final_loc = final_pose_skeleton[:, children[i]] - rotate_rest_pose[:, i]
+
                 orig_vec = rel_pose_skeleton[:, children[i]]
                 template_vec = rel_rest_pose[:, children[i]]
                 norm_t = torch.norm(template_vec, dim=1, keepdim=True)
                 orig_vec = orig_vec * norm_t / torch.norm(
                     orig_vec, dim=1, keepdim=True)
 
-                diff = torch.norm(
-                    child_final_loc - orig_vec, dim=1, keepdim=True)
+                diff = torch.norm(child_final_loc - orig_vec, dim=1, keepdim=True)
                 big_diff_idx = torch.where(diff > 15 / 1000)[0]
 
                 child_final_loc[big_diff_idx] = orig_vec[big_diff_idx]
 
-            child_final_loc = torch.matmul(
-                rot_mat_chain[parents[i]].transpose(1, 2), child_final_loc)
 
-            child_rest_loc = rel_rest_pose[:, children[i]]
+            # vec_p_k = R_pa(k).T * (p_k - p_pa(k))
+            child_final_loc = torch.matmul(rot_mat_chain[parents[i]].transpose(1, 2), child_final_loc)
+
             # (B, 1, 1)
             child_final_norm = torch.norm(child_final_loc, dim=1, keepdim=True)
             child_rest_norm = torch.norm(child_rest_loc, dim=1, keepdim=True)
 
-            child_final_norm = torch.norm(child_final_loc, dim=1, keepdim=True)
-
-            # (B, 3, 1)
+            # vec_n
             axis = torch.cross(child_rest_loc, child_final_loc, dim=1)
             axis_norm = torch.norm(axis, dim=1, keepdim=True)
 
@@ -227,7 +236,6 @@ def batch_inverse_kinematics_transform(pose_skeleton,
     rot_mats = torch.stack(rot_mat_local, dim=1)
 
     return rot_mats, rotate_rest_pose.squeeze(-1)
-
 
 def batch_get_pelvis_orient_svd(rel_pose_skeleton, rel_rest_pose, parents,
                                 children, dtype):


### PR DESCRIPTION
1.  Use naive HybrIK instead of adaptive HybrIK during training.
2. The results of the upgraded HybrIK on 3DPW:
PA-MPJPE: 50.30 -> 49.02 
MPJPE: 86.92 -> 81.08.