### PR TITLE
[Fix] Store rotated smpl parameters

### DIFF
--- a/mmhuman3d/data/datasets/pipelines/transforms.py
+++ b/mmhuman3d/data/datasets/pipelines/transforms.py
@@ -280,7 +280,7 @@ def _rotate_smpl_pose(pose, rot):
         rot_mat = _construct_rotation_matrix(-rot)
         orient = pose[:3]
         # find the rotation of the body in camera frame
-        per_rdg, _ = cv2.Rodrigues(orient)
+        per_rdg, _ = cv2.Rodrigues(orient.astype(np.float32))
         # apply the global rotation to the global orientation
         res_rot, _ = cv2.Rodrigues(np.dot(rot_mat, per_rdg))
         pose_rotated[:3] = (res_rot.T)[0]

--- a/mmhuman3d/data/datasets/pipelines/transforms.py
+++ b/mmhuman3d/data/datasets/pipelines/transforms.py
@@ -705,7 +705,7 @@ class MeshAffine:
             body_pose = results['smpl_body_pose'].copy().reshape((-1))
             pose = np.concatenate((global_orient, body_pose), axis=-1)
             pose = _rotate_smpl_pose(pose, r)
-            results['global_orient'] = pose[:3]
-            results['body_pose'] = pose[3:].reshape((-1, 3))
+            results['smpl_global_orient'] = pose[:3]
+            results['smpl_body_pose'] = pose[3:].reshape((-1, 3))
 
         return results

--- a/tests/test_datasets/test_human_image_dataset.py
+++ b/tests/test_datasets/test_human_image_dataset.py
@@ -1,6 +1,13 @@
+import copy
+
 import numpy as np
 
 from mmhuman3d.data.datasets import HumanImageDataset
+from mmhuman3d.data.datasets.pipelines import (
+    LoadImageFromFile,
+    MeshAffine,
+    RandomHorizontalFlip,
+)
 
 
 def test_human_image_dataset():
@@ -83,6 +90,66 @@ def test_human_image_dataset():
     assert res['MPJPE-PA'] > 0
 
 
+def test_pipeline():
+    train_dataset = HumanImageDataset(
+        data_prefix='tests/data',
+        pipeline=[],
+        dataset_name='3dpw',
+        ann_file='sample_3dpw_train.npz')
+
+    info = train_dataset.prepare_raw_data(0)
+
+    # keypoints2d and 3d
+    info['keypoints2d'] = np.random.rand(*info['keypoints2d'].shape).astype(
+        np.float32)
+    info['keypoints3d'] = np.random.rand(*info['keypoints3d'].shape).astype(
+        np.float32)
+    info['smpl_body_pose'] = info['smpl_body_pose'].astype('f')
+
+    # test loading image
+    transform = LoadImageFromFile()
+    results = transform(copy.deepcopy(info))
+
+    # test no flip
+    original_img = results['img']
+    original_keypoints2d = results['keypoints2d']
+    original_keypoints3d = results['keypoints3d']
+    original_body_pose = results['smpl_body_pose']
+
+    transform = RandomHorizontalFlip(flip_prob=0., convention='smpl_54')
+    results_no_flip = transform(copy.deepcopy(results))
+    assert np.equal(results_no_flip['img'], original_img).all()
+    assert np.equal(results_no_flip['keypoints2d'], original_keypoints2d).all()
+    assert np.equal(results_no_flip['keypoints3d'], original_keypoints3d).all()
+    assert np.equal(results_no_flip['smpl_body_pose'],
+                    original_body_pose).all()
+
+    # test flip
+    transform = RandomHorizontalFlip(flip_prob=1., convention='smpl_54')
+    results_flip_smpl = transform(copy.deepcopy(results))
+    assert not np.equal(results_flip_smpl['img'], original_img).all()
+    assert not np.equal(results_flip_smpl['keypoints3d'],
+                        original_keypoints3d).all()
+    assert not np.equal(results_flip_smpl['keypoints2d'],
+                        original_keypoints2d).all()
+    assert not np.equal(results_flip_smpl['smpl_body_pose'],
+                        original_body_pose).all()
+
+    # test random affine
+    transform = MeshAffine(img_res=224)
+    results['rotation'] = 30
+    results['scale'] = 0.25 * results['scale']
+    results_affine = transform(copy.deepcopy(results))
+    assert results_affine['img'].shape == (224, 224, 3)
+    assert not np.equal(results_affine['img'].shape, original_img.shape).all()
+    assert not np.equal(results_affine['keypoints3d'],
+                        original_keypoints3d).all()
+    assert not np.equal(results_affine['keypoints2d'],
+                        original_keypoints2d).all()
+    assert not np.equal(results_affine['smpl_body_pose'],
+                        original_body_pose).all()
+
+
 def test_human_image_dataset_smc():
     # test loading smc
     train_dataset = HumanImageDataset(
@@ -100,3 +167,7 @@ def test_human_image_dataset_smc():
     for i, data in enumerate(train_dataset):
         for key in data_keys:
             assert key in data
+
+
+if __name__ == '__main__':
+    test_pipeline()

--- a/tests/test_datasets/test_human_image_dataset.py
+++ b/tests/test_datasets/test_human_image_dataset.py
@@ -132,7 +132,7 @@ def test_pipeline():
                         original_keypoints3d).all()
     assert not np.equal(results_flip_smpl['keypoints2d'],
                         original_keypoints2d).all()
-    assert not np.equal(results_flip_smpl['smpl_body_pose'],
+    assert not np.equal(results_flip_smpl['smpl_global_orient'],
                         original_body_pose).all()
 
     # test random affine
@@ -146,7 +146,7 @@ def test_pipeline():
                         original_keypoints3d).all()
     assert not np.equal(results_affine['keypoints2d'],
                         original_keypoints2d).all()
-    assert not np.equal(results_affine['smpl_body_pose'],
+    assert not np.equal(results_affine['smpl_global_orient'],
                         original_body_pose).all()
 
 

--- a/tests/test_datasets/test_human_image_dataset.py
+++ b/tests/test_datasets/test_human_image_dataset.py
@@ -167,7 +167,3 @@ def test_human_image_dataset_smc():
     for i, data in enumerate(train_dataset):
         for key in data_keys:
             assert key in data
-
-
-if __name__ == '__main__':
-    test_pipeline()


### PR DESCRIPTION
Address bug in data augmentation where rotated smpl parameters were assigned wrongly and therefore not stored