### PR TITLE
[Fix] Fix GPU memory leak

### DIFF
--- a/mmhuman3d/data/data_converters/gta_human.py
+++ b/mmhuman3d/data/data_converters/gta_human.py
@@ -25,13 +25,12 @@ from .builder import DATA_CONVERTERS
 class GTAHumanConverter(BaseConverter):
     """GTA-Human dataset `Playing for 3D Human Recovery' arXiv`2021 More
     details can be found in the `paper.
-
     <https://arxiv.org/pdf/2110.07588.pdf>`__.
     """
 
     def __init__(self, *args, **kwargs):
         super(GTAHumanConverter, self).__init__(*args, **kwargs)
-        
+
         focal_length = 1158.0337
         camera_center = (960, 540)  # xy
         image_size = (1080, 1920)  # (height, width)
@@ -45,8 +44,8 @@ class GTAHumanConverter(BaseConverter):
                 keypoint_src='smpl_54',
                 keypoint_dst='smpl_49',
                 model_path='data/body_models/smpl',
-                extra_joints_regressor='data/body_models/J_regressor_extra.npy')
-        ).to(device)
+                extra_joints_regressor='data/body_models/J_regressor_extra.npy'
+            )).to(device)
 
         self.camera = build_cameras(
             dict(
@@ -63,7 +62,6 @@ class GTAHumanConverter(BaseConverter):
             dataset_path (str): Path to directory where raw images and
             annotations are stored.
             out_path (str): Path to directory to save preprocessed npz file
-
         Returns:
             dict:
                 A dict containing keys video_path, smplh, meta, frame_idx

--- a/mmhuman3d/data/data_converters/gta_human.py
+++ b/mmhuman3d/data/data_converters/gta_human.py
@@ -36,7 +36,7 @@ class GTAHumanConverter(BaseConverter):
         camera_center = (960, 540)  # xy
         image_size = (1080, 1920)  # (height, width)
 
-        device = torch.device(
+        self.device = torch.device(
             'cuda') if torch.cuda.is_available() else torch.device('cpu')
 
         self.smpl = build_body_model(
@@ -46,7 +46,7 @@ class GTAHumanConverter(BaseConverter):
                 keypoint_dst='smpl_49',
                 model_path='data/body_models/smpl',
                 extra_joints_regressor='data/body_models/J_regressor_extra.npy'
-            )).to(device)
+            )).to(self.device)
 
         self.camera = build_cameras(
             dict(
@@ -55,7 +55,7 @@ class GTAHumanConverter(BaseConverter):
                 in_ndc=False,
                 focal_length=focal_length,
                 image_size=image_size,
-                principal_point=camera_center)).to(device)
+                principal_point=camera_center)).to(self.device)
 
     def convert(self, dataset_path: str, out_path: str) -> dict:
         """

--- a/mmhuman3d/data/data_converters/gta_human.py
+++ b/mmhuman3d/data/data_converters/gta_human.py
@@ -25,6 +25,7 @@ from .builder import DATA_CONVERTERS
 class GTAHumanConverter(BaseConverter):
     """GTA-Human dataset `Playing for 3D Human Recovery' arXiv`2021 More
     details can be found in the `paper.
+
     <https://arxiv.org/pdf/2110.07588.pdf>`__.
     """
 
@@ -54,7 +55,7 @@ class GTAHumanConverter(BaseConverter):
                 in_ndc=False,
                 focal_length=focal_length,
                 image_size=image_size,
-                principal_point=camera_center))
+                principal_point=camera_center)).to(device)
 
     def convert(self, dataset_path: str, out_path: str) -> dict:
         """

--- a/mmhuman3d/data/data_converters/gta_human.py
+++ b/mmhuman3d/data/data_converters/gta_human.py
@@ -29,30 +29,33 @@ class GTAHumanConverter(BaseConverter):
     <https://arxiv.org/pdf/2110.07588.pdf>`__.
     """
 
-    focal_length = 1158.0337
-    camera_center = (960, 540)  # xy
-    image_size = (1080, 1920)  # (height, width)
+    def __init__(self, *args, **kwargs):
+        super(GTAHumanConverter, self).__init__(*args, **kwargs)
+        
+        focal_length = 1158.0337
+        camera_center = (960, 540)  # xy
+        image_size = (1080, 1920)  # (height, width)
 
-    device = torch.device(
-        'cuda') if torch.cuda.is_available() else torch.device('cpu')
+        device = torch.device(
+            'cuda') if torch.cuda.is_available() else torch.device('cpu')
 
-    smpl = build_body_model(
-        dict(
-            type='SMPL',
-            keypoint_src='smpl_54',
-            keypoint_dst='smpl_49',
-            model_path='data/body_models/smpl',
-            extra_joints_regressor='data/body_models/J_regressor_extra.npy')
-    ).to(device)
+        self.smpl = build_body_model(
+            dict(
+                type='SMPL',
+                keypoint_src='smpl_54',
+                keypoint_dst='smpl_49',
+                model_path='data/body_models/smpl',
+                extra_joints_regressor='data/body_models/J_regressor_extra.npy')
+        ).to(device)
 
-    camera = build_cameras(
-        dict(
-            type='PerspectiveCameras',
-            convention='opencv',
-            in_ndc=False,
-            focal_length=focal_length,
-            image_size=image_size,
-            principal_point=camera_center))
+        self.camera = build_cameras(
+            dict(
+                type='PerspectiveCameras',
+                convention='opencv',
+                in_ndc=False,
+                focal_length=focal_length,
+                image_size=image_size,
+                principal_point=camera_center))
 
     def convert(self, dataset_path: str, out_path: str) -> dict:
         """


### PR DESCRIPTION
Resolves #96: Init camera and SMPl statically waste GPU memory and lead to GPU memory unbalance (all these models are loaded on GPU:0).