### PR TITLE
[Fix] Fix shape and device in tensor2dict

### DIFF
--- a/mmhuman3d/models/body_models/smpl.py
+++ b/mmhuman3d/models/body_models/smpl.py
@@ -169,11 +169,10 @@ class SMPL(_SMPL):
         global_orient = full_pose[:, :3]
         batch_size = full_pose.shape[0]
         if betas is not None:
-            try:
-                betas = betas.view(batch_size, -1)
-            # if betas not divided by batch_size, repeat it
-            except RuntimeError:
-                betas = betas.view(1, -1).repeat(batch_size, 1)
+            # squeeze or unsqueeze betas to 2 dims
+            betas = betas.view(-1, betas.shape[-1])
+            if betas.shape[0] == 1:
+                betas = betas.repeat(batch_size, 1)
         else:
             betas = betas
         transl = transl.view(batch_size, -1) if transl is not None else transl

--- a/mmhuman3d/models/body_models/smpl.py
+++ b/mmhuman3d/models/body_models/smpl.py
@@ -169,6 +169,9 @@ class SMPL(_SMPL):
         global_orient = full_pose[:, :3]
         batch_size = full_pose.shape[0]
         betas = betas.view(batch_size, -1) if betas is not None else betas
+        betas = betas.repeat(full_pose.shape[0], 1) \
+            if betas is not None and betas.shape[0] == 1\
+            else betas
         transl = transl.view(batch_size, -1) if transl is not None else transl
         return {
             'betas': betas,

--- a/mmhuman3d/models/body_models/smpl.py
+++ b/mmhuman3d/models/body_models/smpl.py
@@ -169,10 +169,11 @@ class SMPL(_SMPL):
         global_orient = full_pose[:, :3]
         batch_size = full_pose.shape[0]
         if betas is not None:
-            if betas.shape[0] == 1:
-                betas = betas.repeat(full_pose.shape[0], 1)
-            else:
+            try:
                 betas = betas.view(batch_size, -1)
+            # if betas not divided by batch_size, repeat it
+            except RuntimeError:
+                betas = betas.view(1, -1).repeat(batch_size, 1)
         else:
             betas = betas
         transl = transl.view(batch_size, -1) if transl is not None else transl

--- a/mmhuman3d/models/body_models/smpl.py
+++ b/mmhuman3d/models/body_models/smpl.py
@@ -168,10 +168,13 @@ class SMPL(_SMPL):
         body_pose = full_pose[:, 3:]
         global_orient = full_pose[:, :3]
         batch_size = full_pose.shape[0]
-        betas = betas.view(batch_size, -1) if betas is not None else betas
-        betas = betas.repeat(full_pose.shape[0], 1) \
-            if betas is not None and betas.shape[0] == 1\
-            else betas
+        if betas is not None:
+            if betas.shape[0] == 1:
+                betas = betas.repeat(full_pose.shape[0], 1)
+            else:
+                betas = betas.view(batch_size, -1)
+        else:
+            betas = betas
         transl = transl.view(batch_size, -1) if transl is not None else transl
         return {
             'betas': betas,

--- a/mmhuman3d/models/body_models/smplx.py
+++ b/mmhuman3d/models/body_models/smplx.py
@@ -178,10 +178,11 @@ class SMPLX(_SMPLX):
                                     NUM_BODY_JOINTS + 19:NUM_BODY_JOINTS + 34]
         batch_size = body_pose.shape[0]
         if betas is not None:
-            if betas.shape[0] == 1:
-                betas = betas.repeat(full_pose.shape[0], 1)
-            else:
+            try:
                 betas = betas.view(batch_size, -1)
+            # if betas not divided by batch_size, repeat it
+            except RuntimeError:
+                betas = betas.view(1, -1).repeat(batch_size, 1)
         else:
             betas = betas
         transl = transl.view(batch_size, -1) if transl is not None else transl

--- a/mmhuman3d/models/body_models/smplx.py
+++ b/mmhuman3d/models/body_models/smplx.py
@@ -178,11 +178,10 @@ class SMPLX(_SMPLX):
                                     NUM_BODY_JOINTS + 19:NUM_BODY_JOINTS + 34]
         batch_size = body_pose.shape[0]
         if betas is not None:
-            try:
-                betas = betas.view(batch_size, -1)
-            # if betas not divided by batch_size, repeat it
-            except RuntimeError:
-                betas = betas.view(1, -1).repeat(batch_size, 1)
+            # squeeze or unsqueeze betas to 2 dims
+            betas = betas.view(-1, betas.shape[-1])
+            if betas.shape[0] == 1:
+                betas = betas.repeat(batch_size, 1)
         else:
             betas = betas
         transl = transl.view(batch_size, -1) if transl is not None else transl

--- a/mmhuman3d/models/body_models/smplx.py
+++ b/mmhuman3d/models/body_models/smplx.py
@@ -177,10 +177,13 @@ class SMPLX(_SMPLX):
         right_hand_pose = full_pose[:,
                                     NUM_BODY_JOINTS + 19:NUM_BODY_JOINTS + 34]
         batch_size = body_pose.shape[0]
-        betas = betas.view(batch_size, -1) if betas is not None else betas
-        betas = betas.repeat(full_pose.shape[0], 1) \
-            if betas is not None and betas.shape[0] == 1\
-            else betas
+        if betas is not None:
+            if betas.shape[0] == 1:
+                betas = betas.repeat(full_pose.shape[0], 1)
+            else:
+                betas = betas.view(batch_size, -1)
+        else:
+            betas = betas
         transl = transl.view(batch_size, -1) if transl is not None else transl
         expression = expression.view(
             batch_size, -1) if expression is not None else torch.zeros(

--- a/mmhuman3d/models/body_models/smplx.py
+++ b/mmhuman3d/models/body_models/smplx.py
@@ -178,10 +178,13 @@ class SMPLX(_SMPLX):
                                     NUM_BODY_JOINTS + 19:NUM_BODY_JOINTS + 34]
         batch_size = body_pose.shape[0]
         betas = betas.view(batch_size, -1) if betas is not None else betas
+        betas = betas.repeat(full_pose.shape[0], 1) \
+            if betas is not None and betas.shape[0] == 1\
+            else betas
         transl = transl.view(batch_size, -1) if transl is not None else transl
         expression = expression.view(
             batch_size, -1) if expression is not None else torch.zeros(
-                batch_size, 10)
+                batch_size, 10).to(body_pose.device)
         return {
             'betas':
             betas,

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,4 +1,4 @@
-cdflib
+cdflib<0.4.0
 chumpy
 colormap
 easydev

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -1,3 +1,4 @@
+astropy
 cdflib<0.4.0
 chumpy
 colormap


### PR DESCRIPTION
Resolve https://github.com/open-mmlab/mmhuman3d/issues/125
* When expression is None, the new zero tensor will be put onto the correct device
* If a betas in shape [1, 10] is given, the new method will repeat it instead of view(b_size, -1), which causes error all the time.