### PR TITLE
[Feature] Add SmoothNet

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ Supported methods:
 - [x] [HybrIK](https://jeffli.site/HybrIK/) (CVPR'2021)
 - [x] [PARE](https://pare.is.tue.mpg.de/) (ICCV'2021)
 - [x] [DeciWatch](https://ailingzeng.site/deciwatch) (arXiv'2022)
+- [x] [SmoothNet](https://ailingzeng.site/smoothnet) (arXiv'2022)
 
 </details>
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -85,6 +85,7 @@ https://user-images.githubusercontent.com/62529255/144362861-e794b404-c48f-4ebe-
 - [x] [HybrIK](https://jeffli.site/HybrIK/) (CVPR'2021)
 - [x] [PARE](https://pare.is.tue.mpg.de/) (ICCV'2021)
 - [x] [DeciWatch](https://ailingzeng.site/deciwatch) (arXiv'2022)
+- [x] [SmoothNet](https://ailingzeng.site/smoothnet) (arXiv'2022)
 
 </details>
 

--- a/configs/_base_/post_processing/README.md
+++ b/configs/_base_/post_processing/README.md
@@ -21,7 +21,7 @@ We use checkpoints trained on SPIN-3DPW for demo speed up. Checkpoints with diff
 
 
 | Interval |  Window Q  |Config  | Download | Speed Up | Precision Improvement (MPJPE In/Out) |
-|:------:|:-------:|:------:|:------:|:------:|
+|:------:|:-------:|:------:|:------:|:------:|:------:|
 | 10 | 1 |[deciwatch_interval10_q1](deciwatch_interval10_q1.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/deciwatch/deciwatch_interval10_q1.pth.tar?versionId=CAEQOhiBgMChhsS9gxgiIDM5OGUwZGY0MTc4NTQ2M2NhZDEwMzU5MWUzMWNmZjY1)| 10X |99.35 / 95.85|
 | 10 | 2 |[deciwatch_interval10_q2](deciwatch_interval10_q2.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/deciwatch/deciwatch_interval10_q2.pth.tar?versionId=CAEQOhiBgICau8O9gxgiIDk1Y2Y0MzUxMmY0MDQzZThiYzhkMGJlMjc3ZDQ2NTQ2)| 10X | 99.45 / 96.37|
 | 10 | 3 |[deciwatch_interval10_q3](deciwatch_interval10_q3.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/deciwatch/deciwatch_interval10_q3.pth.tar?versionId=CAEQOhiBgICIq8O9gxgiIDZiMjEzMjY3ODA4MTQwNGY5NTU3OWNkZjRjZjI2ZDFi)| 10X | 99.60 / 96.98 |

--- a/configs/_base_/post_processing/README.md
+++ b/configs/_base_/post_processing/README.md
@@ -3,7 +3,6 @@
 We provide two learning-based post-processing methods ```deciwatch``` and ```smoothnet``` for speed-up and smoothing respectively.
 
 ## DeciWatch
-### Introduction
 
 We provide the config files for DeciWatch: [DeciWatch: A Simple Baseline for 10x Efficient 2D and 3D Pose Estimation](https://arxiv.org/pdf/2203.08713.pdf).
 

--- a/configs/_base_/post_processing/README.md
+++ b/configs/_base_/post_processing/README.md
@@ -21,7 +21,7 @@ We use checkpoints trained on SPIN-3DPW for demo speed up. Checkpoints with diff
 
 
 | Interval |  Window Q  |Config  | Download | Speed Up | Precision Improvement (MPJPE In/Out) |
-|:------:|:-------:|:------:|:------:|:------:|:------:|
+|:------:|:-------:|:------:|:------:|:------:|
 | 10 | 1 |[deciwatch_interval10_q1](deciwatch_interval10_q1.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/deciwatch/deciwatch_interval10_q1.pth.tar?versionId=CAEQOhiBgMChhsS9gxgiIDM5OGUwZGY0MTc4NTQ2M2NhZDEwMzU5MWUzMWNmZjY1)| 10X |99.35 / 95.85|
 | 10 | 2 |[deciwatch_interval10_q2](deciwatch_interval10_q2.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/deciwatch/deciwatch_interval10_q2.pth.tar?versionId=CAEQOhiBgICau8O9gxgiIDk1Y2Y0MzUxMmY0MDQzZThiYzhkMGJlMjc3ZDQ2NTQ2)| 10X | 99.45 / 96.37|
 | 10 | 3 |[deciwatch_interval10_q3](deciwatch_interval10_q3.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/deciwatch/deciwatch_interval10_q3.pth.tar?versionId=CAEQOhiBgICIq8O9gxgiIDZiMjEzMjY3ODA4MTQwNGY5NTU3OWNkZjRjZjI2ZDFi)| 10X | 99.60 / 96.98 |
@@ -55,7 +55,7 @@ We use checkpoints trained on SPIN-3DPW for demo pose smoothing. Checkpoints wit
 
 
 | Window Size  |Config  | Download | Precision Improvement (MPJPE In/Out) | Smoothness Improvement (Accel In/Out) |
-|:------:|:-------:|:------:|:------:|:------:|:------:|
+|:------:|:-------:|:------:|:------:|:------:|
 | 8 |[smoothnet_windowsize8](smoothnet_windowsize8.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/smoothnet/smoothnet_windowsize8.pth.tar?versionId=CAEQPhiBgMDo0s7shhgiIDgzNTRmNWM2ZWEzYTQyYzRhNzUwYTkzZWZkMmU5MWEw)| 96.85 / 95.84 | 34.62 / 7.13 |
 | 16 |[smoothnet_windowsize16](smoothnet_windowsize16.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/smoothnet/smoothnet_windowsize16.pth.tar?versionId=CAEQPhiBgMC.s87shhgiIGM3ZTI1ZGY1Y2NhNDQ2YzRiNmEyOGZhY2VjYWFiN2Zi)| 96.85 / 95.61| 34.62 / 6.35 |
 | 32 |[smoothnet_windowsize32](smoothnet_windowsize32.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/smoothnet/smoothnet_windowsize32.pth.tar?versionId=CAEQPhiBgIDf0s7shhgiIDhmYmM3YWQ0ZGI3NjRmZTc4NTk2NDE1MTA2MTUyMGRm)| 96.85 / 95.03 |34.62 / 6.11 |

--- a/configs/_base_/post_processing/README.md
+++ b/configs/_base_/post_processing/README.md
@@ -1,5 +1,9 @@
-# DeciWatch
-## Introduction
+# Learning-Based Post-Processing methods
+
+We provide two learning-based post-processing methods ```deciwatch``` and ```smoothnet``` for speed-up and smoothing respectively.
+
+## DeciWatch
+### Introduction
 
 We provide the config files for DeciWatch: [DeciWatch: A Simple Baseline for 10x Efficient 2D and 3D Pose Estimation](https://arxiv.org/pdf/2203.08713.pdf).
 
@@ -12,7 +16,7 @@ We provide the config files for DeciWatch: [DeciWatch: A Simple Baseline for 10x
 }
 ```
 
-## Notes
+### Notes
 
 We use checkpoints trained on SPIN-3DPW for demo speed up. Checkpoints with different intervals and q values are provided. If you need more checkpoints trained on various datasets and backbones, please refer to the [official implementation of DeciWatch](https://github.com/cure-lab/DeciWatch).
 
@@ -31,3 +35,31 @@ We use checkpoints trained on SPIN-3DPW for demo speed up. Checkpoints with diff
 | 5 | 5 |[deciwatch_interval5_q5](deciwatch_interval5_q5.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/deciwatch/deciwatch_interval5_q5.pth.tar?versionId=CAEQOhiBgMCyq8O9gxgiIDRjMzViMjllNWRiNjRlMzA5ZjczYWIxOGU2OGFkYjdl) |5X | 99.55 / 94.48 |
 
 To use different settings of DeciWatch in demo, specify `--speed_up_type` with the checkpoint name. For example, you may use `--speed_up_type deciwatch_interval10_q3` for 10X speed up with a window size of 31. Simply set `--speed_up_type deciwatch` to use default setting `deciwatch_interval5_q3`. The meaning of interval and q can be found in the original paper.
+
+## SmoothNet
+
+We provide the config files for [SmoothNet: A Plug-and-Play Network for Refining Human Poses in Videos](https://arxiv.org/abs/2112.13715).
+
+
+```BibTeX
+@article{zeng2021smoothnet,
+  title={SmoothNet: A Plug-and-Play Network for Refining Human Poses in Videos},
+  author={Zeng, Ailing and Yang, Lei and Ju, Xuan and Li, Jiefeng and Wang, Jianyi and Xu, Qiang},
+  journal={arXiv preprint arXiv:2112.13715},
+  year={2021}
+}
+```
+
+### Notes
+
+We use checkpoints trained on SPIN-3DPW for demo pose smoothing. Checkpoints with different window size are provided.
+
+
+| Window Size  |Config  | Download | Precision Improvement (MPJPE In/Out) | Smoothness Improvement (Accel In/Out) |
+|:------:|:-------:|:------:|:------:|:------:|:------:|
+| 8 |[smoothnet_windowsize8](smoothnet_windowsize8.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/smoothnet/smoothnet_windowsize8.pth.tar?versionId=CAEQPhiBgMDo0s7shhgiIDgzNTRmNWM2ZWEzYTQyYzRhNzUwYTkzZWZkMmU5MWEw)| 96.85 / 95.84 | 34.62 / 7.13 |
+| 16 |[smoothnet_windowsize16](smoothnet_windowsize16.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/smoothnet/smoothnet_windowsize16.pth.tar?versionId=CAEQPhiBgMC.s87shhgiIGM3ZTI1ZGY1Y2NhNDQ2YzRiNmEyOGZhY2VjYWFiN2Zi)| 96.85 / 95.61| 34.62 / 6.35 |
+| 32 |[smoothnet_windowsize32](smoothnet_windowsize32.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/smoothnet/smoothnet_windowsize32.pth.tar?versionId=CAEQPhiBgIDf0s7shhgiIDhmYmM3YWQ0ZGI3NjRmZTc4NTk2NDE1MTA2MTUyMGRm)| 96.85 / 95.03 |34.62 / 6.11 |
+| 64 |[smoothnet_windowsize64](smoothnet_windowsize64.py)| [model](https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/mmhuman3d/models/smoothnet/smoothnet_windowsize64.pth.tar?versionId=CAEQPhiBgMCyw87shhgiIGEwODI4ZjdiYmFkYTQ0NzZiNDVkODk3MDBlYzE1Y2Rh)| 96.85 / 95.26 | 34.62 / 6.02 |
+
+To use different settings of SmoothNet in demo, specify `--smooth_type` with the checkpoint name. For example, you may use `--smooth_type smoothnet_windowsize8` for pose smoothing with a window size of 8. Simply set `--mooth_type smoothnet` to use default setting `smoothnet_windowsize8`. The meaning of windowsize can be found in the original paper.

--- a/configs/_base_/post_processing/smoothnet_windowsize16.py
+++ b/configs/_base_/post_processing/smoothnet_windowsize16.py
@@ -1,0 +1,8 @@
+# Config for SmoothNet filter trained on SPIN data with a window size of 16.
+smooth_cfg = dict(
+    type='smoothnet',
+    window_size=16,
+    output_size=16,
+    checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+    'mmhuman3d/models/smoothnet/smoothnet_windowsize16.pth.tar?versionId'
+    '=CAEQPhiBgMC.s87shhgiIGM3ZTI1ZGY1Y2NhNDQ2YzRiNmEyOGZhY2VjYWFiN2Zi')

--- a/configs/_base_/post_processing/smoothnet_windowsize32.py
+++ b/configs/_base_/post_processing/smoothnet_windowsize32.py
@@ -1,0 +1,8 @@
+# Config for SmoothNet filter trained on SPIN data with a window size of 32.
+smooth_cfg = dict(
+    type='smoothnet',
+    window_size=32,
+    output_size=32,
+    checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+    'mmhuman3d/models/smoothnet/smoothnet_windowsize32.pth.tar?versionId'
+    '=CAEQPhiBgIDf0s7shhgiIDhmYmM3YWQ0ZGI3NjRmZTc4NTk2NDE1MTA2MTUyMGRm')

--- a/configs/_base_/post_processing/smoothnet_windowsize64.py
+++ b/configs/_base_/post_processing/smoothnet_windowsize64.py
@@ -1,0 +1,8 @@
+# Config for SmoothNet filter trained on SPIN data with a window size of 64.
+smooth_cfg = dict(
+    type='smoothnet',
+    window_size=64,
+    output_size=64,
+    checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+    'mmhuman3d/models/smoothnet/smoothnet_windowsize64.pth.tar?versionId'
+    '=CAEQPhiBgMCyw87shhgiIGEwODI4ZjdiYmFkYTQ0NzZiNDVkODk3MDBlYzE1Y2Rh')

--- a/configs/_base_/post_processing/smoothnet_windowsize8.py
+++ b/configs/_base_/post_processing/smoothnet_windowsize8.py
@@ -1,0 +1,8 @@
+# Config for SmoothNet filter trained on SPIN data with a window size of 8.
+smooth_cfg = dict(
+    type='smoothnet',
+    window_size=8,
+    output_size=8,
+    checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+    'mmhuman3d/models/smoothnet/smoothnet_windowsize8.pth.tar?versionId'
+    '=CAEQPhiBgMDo0s7shhgiIDgzNTRmNWM2ZWEzYTQyYzRhNzUwYTkzZWZkMmU5MWEw')

--- a/demo/estimate_smpl.py
+++ b/demo/estimate_smpl.py
@@ -386,10 +386,10 @@ def multi_person_with_mmtracking(args, frames_iter):
     # smooth
     if args.smooth_type is not None:
         smpl_poses = smooth_process(
-            smpl_poses.reshape(frame_num, max_instance, 24, 9),
+            smpl_poses.reshape(frame_num, -1, 24, 9),
             smooth_type=args.smooth_type)
         verts = smooth_process(verts, smooth_type=args.smooth_type)
-        smpl_poses = smpl_poses.reshape(frame_num, max_instance, 24, 3, 3)
+        smpl_poses = smpl_poses.reshape(frame_num, -1, 24, 3, 3)
 
     if smpl_poses.shape[2:] == (24, 3, 3):
         smpl_poses = rotmat_to_aa(smpl_poses)

--- a/demo/estimate_smpl.py
+++ b/demo/estimate_smpl.py
@@ -216,9 +216,12 @@ def single_person_with_mmdet(args, frames_iter):
     # smooth
     if args.smooth_type is not None:
         smpl_poses = smooth_process(
-            smpl_poses.reshape(frame_num, 24, 9), smooth_type=args.smooth_type)
+            smpl_poses.reshape(frame_num, 24, 9),
+            smooth_type=args.smooth_type).reshape(frame_num, 24, 3, 3)
         verts = smooth_process(verts, smooth_type=args.smooth_type)
-        smpl_poses = smpl_poses.reshape(frame_num, 24, 3, 3)
+        pred_cams = smooth_process(
+            pred_cams[:, np.newaxis],
+            smooth_type=args.smooth_type).reshape(frame_num, 3)
 
     if smpl_poses.shape[1:] == (24, 3, 3):
         smpl_poses = rotmat_to_aa(smpl_poses)
@@ -387,9 +390,11 @@ def multi_person_with_mmtracking(args, frames_iter):
     if args.smooth_type is not None:
         smpl_poses = smooth_process(
             smpl_poses.reshape(frame_num, -1, 24, 9),
-            smooth_type=args.smooth_type)
+            smooth_type=args.smooth_type).reshape(frame_num, -1, 24, 3, 3)
         verts = smooth_process(verts, smooth_type=args.smooth_type)
-        smpl_poses = smpl_poses.reshape(frame_num, -1, 24, 3, 3)
+        pred_cams = smooth_process(
+            pred_cams[:, np.newaxis],
+            smooth_type=args.smooth_type).reshape(frame_num, -1, 3)
 
     if smpl_poses.shape[2:] == (24, 3, 3):
         smpl_poses = rotmat_to_aa(smpl_poses)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -59,8 +59,8 @@ We provide a demo script to estimate SMPL parameters for single-person or multi-
 Some useful configs are explained here:
 
 - If you specify `--output` and `--show_path`, the demo script will save the estimated results into `human_data` and render the estimated human mesh.
-- If you specify `--smooth_type`, the demo will be smoothed using specific method. We now support `guas1d`,`oneeuro`, and `savgol`.
-- If you specify `--speed_up_type`, the demo will be processed more quickly using specific method. We now support learning-based method `deciwatch`, more information can be find  [here](../configs/_base_/post_processing/README.md).
+- If you specify `--smooth_type`, the demo will be smoothed using specific method. We now support filters `guas1d`,`oneeuro`, `savgol` and learning-based method `smoothnet`, more information can be find [here](../configs/_base_/post_processing/README.md).
+- If you specify `--speed_up_type`, the demo will be processed more quickly using specific method. We now support learning-based method `deciwatch`, more information can be find [here](../configs/_base_/post_processing/README.md).
 ### Single-person
 
 ```shell
@@ -111,7 +111,7 @@ python demo/estimate_smpl.py \
 ```
 Example:
 ```shell
-python demo/estimate_smpl_image.py \
+python demo/estimate_smpl.py \
     configs/hmr/resnet50_hmr_pw3d.py \
     data/checkpoints/resnet50_hmr_pw3d.pth \
     --multi_person_demo \

--- a/mmhuman3d/core/post_processing/__init__.py
+++ b/mmhuman3d/core/post_processing/__init__.py
@@ -2,9 +2,14 @@ from .builder import build_post_processing
 from .smooth.gaus1d_filter import Gaus1dFilter
 from .smooth.oneeuro_filter import OneEuroFilter
 from .smooth.savgol_filter import SGFilter
-from .speed_up.deciwatch import DeciWatch
+from .smooth.smoothnet import SmoothNetFilter
+from .speed_up.deciwatch import DeciWatchPostProcessing
 
 __all__ = [
-    'build_post_processing', 'OneEuroFilter', 'SGFilter', 'Gaus1dFilter',
-    'DeciWatch'
+    'build_post_processing',
+    'OneEuroFilter',
+    'SGFilter',
+    'Gaus1dFilter',
+    'SmoothNetFilter',
+    'DeciWatchPostProcessing',
 ]

--- a/mmhuman3d/core/post_processing/smooth/smoothnet.py
+++ b/mmhuman3d/core/post_processing/smooth/smoothnet.py
@@ -20,7 +20,7 @@ class SmoothNetResBlock(nn.Module):
         Output: (*, in_channels)
     """
 
-    def __init__(self, in_channels, hidden_channels, dropout=0.5):
+    def __init__(self, in_channels, hidden_channels, dropout=0.1):
         super().__init__()
         self.linear1 = nn.Linear(in_channels, hidden_channels)
         self.linear2 = nn.Linear(hidden_channels, in_channels)
@@ -68,9 +68,9 @@ class SmoothNet(nn.Module):
                  window_size: int,
                  output_size: int,
                  hidden_size: int = 512,
-                 res_hidden_size: int = 256,
-                 num_blocks: int = 3,
-                 dropout: float = 0.5):
+                 res_hidden_size: int = 512,
+                 num_blocks: int = 5,
+                 dropout: float = 0.1):
         super().__init__()
         self.window_size = window_size
         self.output_size = output_size
@@ -163,7 +163,7 @@ class SmoothNetFilter:
         checkpoint: Optional[str] = None,
         hidden_size: int = 512,
         res_hidden_size: int = 512,
-        num_blocks: int = 3,
+        num_blocks: int = 5,
         device: str = 'cpu',
     ):
         super(SmoothNetFilter, self).__init__()
@@ -173,7 +173,8 @@ class SmoothNetFilter:
                                    res_hidden_size, num_blocks)
         self.smoothnet.to(device)
         if checkpoint:
-            load_checkpoint(self.smoothnet, checkpoint)
+            load_checkpoint(
+                self.smoothnet, checkpoint, map_location=self.device)
         self.smoothnet.eval()
 
         for p in self.smoothnet.parameters():

--- a/mmhuman3d/core/post_processing/smooth/smoothnet.py
+++ b/mmhuman3d/core/post_processing/smooth/smoothnet.py
@@ -1,0 +1,213 @@
+from typing import Optional
+
+import numpy as np
+import torch
+from mmcv.runner import load_checkpoint
+from torch import Tensor, nn
+
+from ..builder import POST_PROCESSING
+
+
+class SmoothNetResBlock(nn.Module):
+    """Residual block module used in SmoothNet.
+
+    Args:
+        in_channels (int): Input channel number.
+        hidden_channels (int): The hidden feature channel number.
+        dropout (float): Dropout probability. Default: 0.5
+    Shape:
+        Input: (*, in_channels)
+        Output: (*, in_channels)
+    """
+
+    def __init__(self, in_channels, hidden_channels, dropout=0.5):
+        super().__init__()
+        self.linear1 = nn.Linear(in_channels, hidden_channels)
+        self.linear2 = nn.Linear(hidden_channels, in_channels)
+        self.lrelu = nn.LeakyReLU(0.2, inplace=True)
+        self.dropout = nn.Dropout(p=dropout, inplace=True)
+
+    def forward(self, x):
+        identity = x
+        x = self.linear1(x)
+        x = self.dropout(x)
+        x = self.lrelu(x)
+        x = self.linear2(x)
+        x = self.dropout(x)
+        x = self.lrelu(x)
+
+        out = x + identity
+        return out
+
+
+class SmoothNet(nn.Module):
+    """SmoothNet is a plug-and-play temporal-only network to refine human
+    poses. It works for 2d/3d/6d pose smoothing.
+    "SmoothNet: A Plug-and-Play Network for Refining Human Poses in Videos",
+    arXiv'2021. More details can be found in the `paper
+    <https://arxiv.org/abs/2112.13715>`__ .
+    Note:
+        N: The batch size
+        T: The temporal length of the pose sequence
+        C: The total pose dimension (e.g. keypoint_number * keypoint_dim)
+    Args:
+        window_size (int): The size of the input window.
+        output_size (int): The size of the output window.
+        hidden_size (int): The hidden feature dimension in the encoder,
+            the decoder and between residual blocks. Default: 512
+        res_hidden_size (int): The hidden feature dimension inside the
+            residual blocks. Default: 256
+        num_blocks (int): The number of residual blocks. Default: 3
+        dropout (float): Dropout probability. Default: 0.5
+    Shape:
+        Input: (N, C, T) the original pose sequence
+        Output: (N, C, T) the smoothed pose sequence
+    """
+
+    def __init__(self,
+                 window_size: int,
+                 output_size: int,
+                 hidden_size: int = 512,
+                 res_hidden_size: int = 256,
+                 num_blocks: int = 3,
+                 dropout: float = 0.5):
+        super().__init__()
+        self.window_size = window_size
+        self.output_size = output_size
+        self.hidden_size = hidden_size
+        self.res_hidden_size = res_hidden_size
+        self.num_blocks = num_blocks
+        self.dropout = dropout
+
+        assert output_size <= window_size, (
+            'The output size should be less than or equal to the window size.',
+            f' Got output_size=={output_size} and window_size=={window_size}')
+
+        # Build encoder layers
+        self.encoder = nn.Sequential(
+            nn.Linear(window_size, hidden_size),
+            nn.LeakyReLU(0.1, inplace=True))
+
+        # Build residual blocks
+        res_blocks = []
+        for _ in range(num_blocks):
+            res_blocks.append(
+                SmoothNetResBlock(
+                    in_channels=hidden_size,
+                    hidden_channels=res_hidden_size,
+                    dropout=dropout))
+        self.res_blocks = nn.Sequential(*res_blocks)
+
+        # Build decoder layers
+        self.decoder = nn.Linear(hidden_size, output_size)
+
+    def forward(self, x: Tensor) -> Tensor:
+        """Forward function."""
+        N, C, T = x.shape
+        num_windows = T - self.window_size + 1
+
+        assert T >= self.window_size, (
+            'Input sequence length must be no less than the window size. ',
+            f'Got x.shape[2]=={T} and window_size=={self.window_size}')
+
+        # Unfold x to obtain input sliding windows
+        # [N, C, num_windows, window_size]
+        x = x.unfold(2, self.window_size, 1)
+
+        # Forward layers
+        x = self.encoder(x)
+        x = self.res_blocks(x)
+        x = self.decoder(x)  # [N, C, num_windows, output_size]
+
+        # Accumulate output ensembles
+        out = x.new_zeros(N, C, T)
+        count = x.new_zeros(T)
+
+        for t in range(num_windows):
+            out[..., t:t + self.output_size] += x[:, :, t]
+            count[t:t + self.output_size] += 1.0
+
+        return out.div(count)
+
+
+@POST_PROCESSING.register_module(name=['SmoothNetFilter', 'smoothnet'])
+class SmoothNetFilter:
+    """Apply SmoothNet filter.
+    "SmoothNet: A Plug-and-Play Network for Refining Human Poses in Videos",
+    arXiv'2021. More details can be found in the `paper
+    <https://arxiv.org/abs/2112.13715>`__ .
+    Args:
+        window_size (int): The size of the filter window. It's also the
+            window_size of SmoothNet model.
+        output_size (int): The output window size of SmoothNet model.
+        checkpoint (str): The checkpoint file of the pretrained SmoothNet
+            model. Please note that `checkpoint` should be matched with
+            `window_size` and `output_size`.
+        hidden_size (int): SmoothNet argument. See :class:`SmoothNet` for
+            details. Default: 512
+        hidden_res_size (int): SmoothNet argument. See :class:`SmoothNet`
+            for details. Default: 256
+        num_blocks (int): SmoothNet argument. See :class:`SmoothNet` for
+            details. Default: 3
+        device (str): Device for model inference. Default: 'cpu'
+        root_index (int, optional): If not None, relative keypoint coordinates
+            will be calculated as the SmoothNet input, by centering the
+            keypoints around the root point. The model output will be
+            converted back to absolute coordinates. Default: None
+    """
+
+    def __init__(
+        self,
+        window_size: int,
+        output_size: int,
+        checkpoint: Optional[str] = None,
+        hidden_size: int = 512,
+        res_hidden_size: int = 512,
+        num_blocks: int = 3,
+        device: str = 'cuda',
+    ):
+        super(SmoothNetFilter, self).__init__()
+        self.window_size = window_size
+        self.device = device
+        self.smoothnet = SmoothNet(window_size, output_size, hidden_size,
+                                   res_hidden_size, num_blocks)
+        if checkpoint:
+            load_checkpoint(self.smoothnet, checkpoint)
+        self.smoothnet.to(device)
+        self.smoothnet.eval()
+
+        for p in self.smoothnet.parameters():
+            p.requires_grad_(False)
+
+    def __call__(self, x: np.ndarray):
+        x_type = 'tensor'
+        if not isinstance(x, torch.Tensor):
+            x_type = 'array'
+
+        assert x.ndim == 3, ('Input should be an array with shape [T, K, C]'
+                             f', but got invalid shape {x.shape}')
+
+        T, K, C = x.shape
+
+        if T < self.window_size:
+            # Skip smoothing if the input length is less than the window size
+            smoothed = x
+        else:
+            if x_type == 'array':
+                dtype = x.dtype
+
+            # Convert to tensor and forward the model
+            with torch.no_grad():
+                if x_type == 'array':
+                    x = torch.tensor(
+                        x, dtype=torch.float32, device=self.device)
+                x = x.view(1, T, K * C).permute(0, 2, 1)  # to [1, KC, T]
+                smoothed = self.smoothnet(x)  # in shape [1, KC, T]
+
+            # Convert model output back to input shape and format
+            smoothed = smoothed.permute(0, 2, 1).view(T, K, C)  # to [T, K, C]
+            if x_type == 'array':
+                smoothed = smoothed.cpu().numpy().astype(
+                    dtype)  # to numpy.ndarray
+
+        return smoothed

--- a/mmhuman3d/core/post_processing/smooth/smoothnet.py
+++ b/mmhuman3d/core/post_processing/smooth/smoothnet.py
@@ -164,16 +164,16 @@ class SmoothNetFilter:
         hidden_size: int = 512,
         res_hidden_size: int = 512,
         num_blocks: int = 3,
-        device: str = 'cuda',
+        device: str = 'cpu',
     ):
         super(SmoothNetFilter, self).__init__()
         self.window_size = window_size
         self.device = device
         self.smoothnet = SmoothNet(window_size, output_size, hidden_size,
                                    res_hidden_size, num_blocks)
+        self.smoothnet.to(device)
         if checkpoint:
             load_checkpoint(self.smoothnet, checkpoint)
-        self.smoothnet.to(device)
         self.smoothnet.eval()
 
         for p in self.smoothnet.parameters():

--- a/mmhuman3d/core/post_processing/speed_up/deciwatch.py
+++ b/mmhuman3d/core/post_processing/speed_up/deciwatch.py
@@ -163,6 +163,37 @@ class PositionEmbeddingSine_1D(nn.Module):
 
 
 class DeciWatch(nn.Module):
+    """Apply DeciWatch framework for 10x efficiency.
+    "DeciWatch: A Simple Baseline for 10× Efficient 2D and 3D Pose Estimation",
+    arXiv'2022. More details can be found in the `paper
+    <https://arxiv.org/pdf/2203.08713>` .
+    Args:
+        input_dim (int): The size of input spatial dimension,
+            e.g., 15*2 for 2d pose on the jhmdb dataset
+        sample_interval (int): DeciWatch argument. See :class:`DeciWatch`
+            for details. The intervals of the uniform sampling.
+            The sampling ratio is: 1/sample_interval. Default: 10
+        encoder_hidden_dim (int): DeciWatch argument. See :class:`DeciWatch`
+            for details. Hidden dimension in the encoder. Default: 64
+        decoder_hidden_dim (int): DeciWatch argument. See :class:`DeciWatch`
+            for details. Hidden dimension in the decoder. Default: 64
+        dropout (float): DeciWatch argument. See :class:`DeciWatch`
+            for details. dropout probability. Default: 0.1
+        nheads (int): DeciWatch argument. See :class:`DeciWatch`
+            for details. Default: 4
+        dim_feedforward (int): DeciWatch argument. See :class:`DeciWatch`
+            for details. Dimension of feed forward layers.
+        enc_layers (int): DeciWatch argument. See :class:`DeciWatch`
+            for details. Layers of the encoder. Default: 5
+        dec_layers (int): DeciWatch argument. See :class:`DeciWatch`
+            for details. Layers of the encoder. Default: 5
+        activation (str): DeciWatch argument. See :class:`DeciWatch`
+            for details. Activation function in deciwatch.
+            Default: 'leaky_relu'
+        pre_norm (bool): DeciWatch argument. See :class:`DeciWatch`
+            for details. Whether to normalize before positional embedding.
+            Default: False
+    """
 
     def __init__(self,
                  input_dim=24 * 6,

--- a/mmhuman3d/utils/demo_utils.py
+++ b/mmhuman3d/utils/demo_utils.py
@@ -314,8 +314,10 @@ def smooth_process(x,
         x (np.ndarray): Shape should be (frame,num_person,K,C)
             or (frame,K,C).
         smooth_type (str, optional): Smooth type.
-            choose in ['oneeuro', 'gaus1d', 'savgol'].
-            Defaults to 'savgol'.
+            choose in ['oneeuro', 'gaus1d', 'savgol','smoothnet',
+                'smoothnet_windowsize8','smoothnet_windowsize16',
+                'smoothnet_windowsize32','smoothnet_windowsize64'].
+            Defaults to 'savgol'. 'smoothnet' is default with windowsize=8.
         cfg_base_dir (str, optional): Config base dir,
                             default configs/_base_/post_processing/
     Raises:
@@ -325,8 +327,14 @@ def smooth_process(x,
         np.ndarray: Smoothed data. The shape should be
             (frame,num_person,K,C) or (frame,K,C).
     """
+    if smooth_type == 'smoothnet':
+        smooth_type = 'smoothnet_windowsize8'
 
-    assert smooth_type in ['oneeuro', 'gaus1d', 'savgol']
+    assert smooth_type in [
+        'oneeuro', 'gaus1d', 'savgol', 'smoothnet_windowsize8',
+        'smoothnet_windowsize16', 'smoothnet_windowsize32',
+        'smoothnet_windowsize64'
+    ]
 
     cfg = os.path.join(cfg_base_dir, smooth_type + '.py')
     if isinstance(cfg, str):

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -433,3 +433,7 @@ def test_data_type_np():
     savgol = build_post_processing(cfg)
     out_o = savgol(noisy_input)
     assert out_g.shape == noisy_input.shape == out_s.shape == out_o.shape
+
+
+if __name__ == '__main__':
+    test_data_type_torch()

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -17,6 +17,46 @@ def test_data_type_torch():
     savgol = build_post_processing(cfg)
     out_o = savgol(noisy_input)
     cfg = dict(
+        type='smoothnet',
+        window_size=8,
+        output_size=8,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize8.pth.tar?versionId'
+        '=CAEQPhiBgMDo0s7shhgiIDgzNTRmNWM2ZWEzYTQyYzRhNzUwYTkzZWZkMmU5MWEw',
+        device='cpu')
+    smoothenet_8 = build_post_processing(cfg)
+    out_s_8 = smoothenet_8(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=16,
+        output_size=16,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize16.pth.tar?versionId'
+        '=CAEQPhiBgMC.s87shhgiIGM3ZTI1ZGY1Y2NhNDQ2YzRiNmEyOGZhY2VjYWFiN2Zi',
+        device='cpu')
+    smoothenet_16 = build_post_processing(cfg)
+    out_s_16 = smoothenet_16(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=32,
+        output_size=32,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize32.pth.tar?versionId'
+        '=CAEQPhiBgIDf0s7shhgiIDhmYmM3YWQ0ZGI3NjRmZTc4NTk2NDE1MTA2MTUyMGRm',
+        device='cpu')
+    smoothenet_32 = build_post_processing(cfg)
+    out_s_32 = smoothenet_32(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=64,
+        output_size=64,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize64.pth.tar?versionId'
+        '=CAEQPhiBgMCyw87shhgiIGEwODI4ZjdiYmFkYTQ0NzZiNDVkODk3MDBlYzE1Y2Rh',
+        device='cpu')
+    smoothenet_64 = build_post_processing(cfg)
+    out_s_64 = smoothenet_64(noisy_input)
+    cfg = dict(
         type='deciwatch',
         interval=5,
         slide_window_q=1,
@@ -127,6 +167,14 @@ def test_data_type_torch():
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_o))
     accel_out_d_5_1 = out_d_5_1[:-2] - 2 * out_d_5_1[1:-1] + out_d_5_1[2:]
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_d_5_1))
+    accel_smoothenet_8 = out_s_8[:-2] - 2 * out_s_8[1:-1] + out_s_8[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_8))
+    accel_smoothenet_16 = out_s_16[:-2] - 2 * out_s_16[1:-1] + out_s_16[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_16))
+    accel_smoothenet_32 = out_s_32[:-2] - 2 * out_s_32[1:-1] + out_s_32[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_32))
+    accel_smoothenet_64 = out_s_64[:-2] - 2 * out_s_64[1:-1] + out_s_64[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_64))
     accel_out_d_5_2 = out_d_5_2[:-2] - 2 * out_d_5_2[1:-1] + out_d_5_2[2:]
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_d_5_2))
     accel_out_d_5_3 = out_d_5_3[:-2] - 2 * out_d_5_3[1:-1] + out_d_5_3[2:]
@@ -146,10 +194,11 @@ def test_data_type_torch():
     accel_out_d_10_5 = out_d_10_5[:-2] - 2 * out_d_10_5[1:-1] + out_d_10_5[2:]
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_d_10_5))
     assert out_g.shape == noisy_input.shape == \
-        out_s.shape == out_o.shape == out_d_5_1.shape == out_d_5_2.shape \
-        == out_d_5_3.shape == out_d_5_4.shape == out_d_5_5.shape \
-        == out_d_10_1.shape == out_d_10_2.shape == out_d_10_3.shape \
-        == out_d_10_4.shape == out_d_10_5.shape
+        out_s.shape == out_o.shape == out_s_8.shape == out_s_16.shape \
+        == out_s_32.shape == out_s_64.shape == out_d_5_1.shape \
+        == out_d_5_2.shape == out_d_5_3.shape == out_d_5_4.shape \
+        == out_d_5_5.shape == out_d_10_1.shape == out_d_10_2.shape \
+        == out_d_10_3.shape == out_d_10_4.shape == out_d_10_5.shape
 
 
 def test_data_type_torch_zero():
@@ -188,6 +237,46 @@ def test_data_type_torch_cuda():
     savgol = build_post_processing(cfg)
     out_o = savgol(noisy_input)
     cfg = dict(
+        type='smoothnet',
+        window_size=8,
+        output_size=8,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize8.pth.tar?versionId'
+        '=CAEQPhiBgMDo0s7shhgiIDgzNTRmNWM2ZWEzYTQyYzRhNzUwYTkzZWZkMmU5MWEw',
+        device='cuda:0')
+    smoothenet_8 = build_post_processing(cfg)
+    out_s_8 = smoothenet_8(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=16,
+        output_size=16,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize16.pth.tar?versionId'
+        '=CAEQPhiBgMC.s87shhgiIGM3ZTI1ZGY1Y2NhNDQ2YzRiNmEyOGZhY2VjYWFiN2Zi',
+        device='cuda:0')
+    smoothenet_16 = build_post_processing(cfg)
+    out_s_16 = smoothenet_16(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=32,
+        output_size=32,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize32.pth.tar?versionId'
+        '=CAEQPhiBgIDf0s7shhgiIDhmYmM3YWQ0ZGI3NjRmZTc4NTk2NDE1MTA2MTUyMGRm',
+        device='cuda:0')
+    smoothenet_32 = build_post_processing(cfg)
+    out_s_32 = smoothenet_32(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=64,
+        output_size=64,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize64.pth.tar?versionId'
+        '=CAEQPhiBgMCyw87shhgiIGEwODI4ZjdiYmFkYTQ0NzZiNDVkODk3MDBlYzE1Y2Rh',
+        device='cuda:0')
+    smoothenet_64 = build_post_processing(cfg)
+    out_s_64 = smoothenet_64(noisy_input)
+    cfg = dict(
         type='deciwatch',
         interval=5,
         slide_window_q=1,
@@ -296,6 +385,14 @@ def test_data_type_torch_cuda():
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_s))
     accel_out_o = out_o[:-2] - 2 * out_o[1:-1] + out_o[2:]
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_o))
+    accel_smoothenet_8 = out_s_8[:-2] - 2 * out_s_8[1:-1] + out_s_8[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_8))
+    accel_smoothenet_16 = out_s_16[:-2] - 2 * out_s_16[1:-1] + out_s_16[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_16))
+    accel_smoothenet_32 = out_s_32[:-2] - 2 * out_s_32[1:-1] + out_s_32[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_32))
+    accel_smoothenet_64 = out_s_64[:-2] - 2 * out_s_64[1:-1] + out_s_64[2:]
+    assert accel_input_abs >= torch.mean(torch.abs(accel_smoothenet_64))
     accel_out_d_5_1 = out_d_5_1[:-2] - 2 * out_d_5_1[1:-1] + out_d_5_1[2:]
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_d_5_1))
     accel_out_d_5_2 = out_d_5_2[:-2] - 2 * out_d_5_2[1:-1] + out_d_5_2[2:]
@@ -317,10 +414,11 @@ def test_data_type_torch_cuda():
     accel_out_d_10_5 = out_d_10_5[:-2] - 2 * out_d_10_5[1:-1] + out_d_10_5[2:]
     assert accel_input_abs >= torch.mean(torch.abs(accel_out_d_10_5))
     assert out_g.shape == noisy_input.shape == \
-        out_s.shape == out_o.shape == out_d_5_1.shape == out_d_5_2.shape \
-        == out_d_5_3.shape == out_d_5_4.shape == out_d_5_5.shape \
-        == out_d_10_1.shape == out_d_10_2.shape == out_d_10_3.shape \
-        == out_d_10_4.shape == out_d_10_5.shape
+        out_s.shape == out_o.shape == out_s_8.shape == out_s_16.shape \
+        == out_s_32.shape == out_s_64.shape == out_d_5_1.shape \
+        == out_d_5_2.shape == out_d_5_3.shape == out_d_5_4.shape \
+        == out_d_5_5.shape == out_d_10_1.shape == out_d_10_2.shape \
+        == out_d_10_3.shape == out_d_10_4.shape == out_d_10_5.shape
 
 
 def test_data_type_np():
@@ -335,7 +433,3 @@ def test_data_type_np():
     savgol = build_post_processing(cfg)
     out_o = savgol(noisy_input)
     assert out_g.shape == noisy_input.shape == out_s.shape == out_o.shape
-
-
-if __name__ == '__main__':
-    test_data_type_torch()

--- a/tests/test_post_processing.py
+++ b/tests/test_post_processing.py
@@ -432,8 +432,45 @@ def test_data_type_np():
     cfg = dict(type='SGFilter', window_size=5, polyorder=2)
     savgol = build_post_processing(cfg)
     out_o = savgol(noisy_input)
-    assert out_g.shape == noisy_input.shape == out_s.shape == out_o.shape
-
-
-if __name__ == '__main__':
-    test_data_type_torch()
+    cfg = dict(
+        type='smoothnet',
+        window_size=8,
+        output_size=8,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize8.pth.tar?versionId'
+        '=CAEQPhiBgMDo0s7shhgiIDgzNTRmNWM2ZWEzYTQyYzRhNzUwYTkzZWZkMmU5MWEw',
+        device='cpu')
+    smoothenet_8 = build_post_processing(cfg)
+    out_s_8 = smoothenet_8(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=16,
+        output_size=16,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize16.pth.tar?versionId'
+        '=CAEQPhiBgMC.s87shhgiIGM3ZTI1ZGY1Y2NhNDQ2YzRiNmEyOGZhY2VjYWFiN2Zi',
+        device='cpu')
+    smoothenet_16 = build_post_processing(cfg)
+    out_s_16 = smoothenet_16(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=32,
+        output_size=32,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize32.pth.tar?versionId'
+        '=CAEQPhiBgIDf0s7shhgiIDhmYmM3YWQ0ZGI3NjRmZTc4NTk2NDE1MTA2MTUyMGRm',
+        device='cpu')
+    smoothenet_32 = build_post_processing(cfg)
+    out_s_32 = smoothenet_32(noisy_input)
+    cfg = dict(
+        type='smoothnet',
+        window_size=64,
+        output_size=64,
+        checkpoint='https://openmmlab-share.oss-cn-hangzhou.aliyuncs.com/'
+        'mmhuman3d/models/smoothnet/smoothnet_windowsize64.pth.tar?versionId'
+        '=CAEQPhiBgMCyw87shhgiIGEwODI4ZjdiYmFkYTQ0NzZiNDVkODk3MDBlYzE1Y2Rh',
+        device='cpu')
+    smoothenet_64 = build_post_processing(cfg)
+    out_s_64 = smoothenet_64(noisy_input)
+    assert out_g.shape == noisy_input.shape == out_s.shape == out_o.shape \
+        == out_s_8.shape == out_s_16.shape == out_s_32.shape == out_s_64.shape


### PR DESCRIPTION
Add SmoothNet as a smoothing method for demo inference, which can achieve both better inference precision and visualization for image-based and video-based pose estimation models. Here are some demos:
- HMR without smoothing:
  	
https://user-images.githubusercontent.com/89566272/169288046-0757f3b3-faf1-4fd9-be9b-bb8b92fdb7e9.mov

- HMR with SmoothNet:

https://user-images.githubusercontent.com/89566272/169288286-69bfac0d-d8f2-4bfc-9cd3-453cd2ec590a.mov

- HMR with Savgol Filter:

https://user-images.githubusercontent.com/89566272/169288683-c469e48c-6b0f-44a3-9e64-5545c5cdc972.mov


