### PR TITLE
[Doc] Update dependencies version

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@
 Optional:
 - [MMPOSE](https://github.com/open-mmlab/mmpose) (Only for demo.)
 - [MMDETECTION](https://github.com/open-mmlab/mmdetection) (Only for demo.)
-- [MMTRACKING](https://github.com/open-mmlab/mmtracking) (Only for multi-person demo. If you use mmtrack, please install mmcls<0.23.1, mmcv-full>=1.3.16,<1.6.0 for GPU
+- [MMTRACKING](https://github.com/open-mmlab/mmtracking) (Only for multi-person demo. If you use mmtrack, please install mmcls<0.23.1, mmcv-full>=1.3.17,<1.6.0 for GPU
 
 ## Prepare environment
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@
 Optional:
 - [MMPOSE](https://github.com/open-mmlab/mmpose) (Only for demo.)
 - [MMDETECTION](https://github.com/open-mmlab/mmdetection) (Only for demo.)
-- [MMTRACKING](https://github.com/open-mmlab/mmtracking) (Only for multi-person demo. If you use mmtrack, please install mmcls<0.23.1, mmcv-full>=1.3.17,<1.6.0 for GPU
+- [MMTRACKING](https://github.com/open-mmlab/mmtracking) (Only for multi-person demo. If you use mmtrack, please install mmcls<0.23.1, mmcv-full>=1.3.17,<1.6.0 for GPU.)
 
 ## Prepare environment
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -116,7 +116,7 @@ For more version download link, refer to [openmmlab-download](https://download.o
 Optionally you can choose to compile mmcv from source by the following command
 
 ```shell
-git clone https://github.com/open-mmlab/mmcv.git -b v1.4.2
+git clone https://github.com/open-mmlab/mmcv.git -b v1.3.17
 cd mmcv
 MMCV_WITH_OPS=1 pip install -e .  # package mmcv-full, which contains cuda ops, will be installed after this step
 # OR pip install -e .  # package mmcv, which contains no cuda ops, will be installed after this step

--- a/docs/install.md
+++ b/docs/install.md
@@ -23,7 +23,7 @@
 Optional:
 - [MMPOSE](https://github.com/open-mmlab/mmpose) (Only for demo.)
 - [MMDETECTION](https://github.com/open-mmlab/mmdetection) (Only for demo.)
-- [MMTRACKING](https://github.com/open-mmlab/mmtracking) (Only for multi-person demo. If you use mmtrack, please install mmcls<1.18.0, mmcv-full>=1.3.16,<1.6.0 for GPU
+- [MMTRACKING](https://github.com/open-mmlab/mmtracking) (Only for multi-person demo. If you use mmtrack, please install mmcls<0.23.1, mmcv-full>=1.3.16,<1.6.0 for GPU
 
 ## Prepare environment
 
@@ -116,7 +116,7 @@ For more version download link, refer to [openmmlab-download](https://download.o
 Optionally you can choose to compile mmcv from source by the following command
 
 ```shell
-git clone https://github.com/open-mmlab/mmcv.git -b v1.3.17
+git clone https://github.com/open-mmlab/mmcv.git -b v1.4.2
 cd mmcv
 MMCV_WITH_OPS=1 pip install -e .  # package mmcv-full, which contains cuda ops, will be installed after this step
 # OR pip install -e .  # package mmcv, which contains no cuda ops, will be installed after this step
@@ -156,13 +156,13 @@ pip install -v -e .
 - mmtracking (optional)
 
 ```shell
-pip install "mmcls<0.18.0" "mmtrack<0.9.0,>=0.8.0"
+pip install "mmcls<0.23.1 " "mmtrack<0.13.0"
 ```
 
 Optionally, you can also build MMTracking from source in case you want to modify the code:
 
 ```shell
-git clone git@github.com:open-mmlab/mmtracking.git -b v0.8.0
+git clone git@github.com:open-mmlab/mmtracking.git -b v0.13.0
 cd mmtracking
 pip install -r requirements/build.txt
 pip install -v -e .  # or "python setup.py develop"
@@ -208,7 +208,7 @@ pip install mmdet
 
 pip install mmpose
 
-pip install "mmcls<0.18.0" "mmtrack<0.9.0,>=0.8.0"
+pip install "mmcls<0.23.1 " "mmtrack<0.13.0"
 
 # install mmhuman3d
 

--- a/docs_zh-CN/install.md
+++ b/docs_zh-CN/install.md
@@ -20,7 +20,7 @@
 Optional:
 - [MMPose](https://github.com/open-mmlab/mmpose) (只用于演示)
 - [MMDetection](https://github.com/open-mmlab/mmdetection) (只用于演示)
-- [MMTracking](https://github.com/open-mmlab/mmtracking) (只用于多人的演示。请安装 mmcls<1.18.0, mmcv-full>=1.3.16,<1.6.0)
+- [MMTracking](https://github.com/open-mmlab/mmtracking) (只用于多人的演示。请安装 mmcls<0.23.1, mmcv-full>=1.3.17,<1.6.0)
 
 ## 准备环境
 
@@ -152,13 +152,13 @@ pip install -v -e .
 - mmtracking (可选)
 
 ```shell
-pip install "mmcls<0.18.0" "mmtrack<0.9.0,>=0.8.0"
+pip install "mmcls<0.23.1" "mmtrack<0.13.0"
 ```
 
 如果您想要修改mmdet的代码，您也可以使用如下命令，从源码构建mmtracking：
 
 ```shell
-git clone git@github.com:open-mmlab/mmtracking.git -b v0.8.0
+git clone git@github.com:open-mmlab/mmtracking.git -b v0.13.0
 cd mmtracking
 pip install -r requirements/build.txt
 pip install -v -e .  # 或者 "python setup.py develop"
@@ -204,7 +204,7 @@ pip install mmdet
 
 pip install mmpose
 
-pip install "mmcls<0.18.0" "mmtrack<0.9.0,>=0.8.0"
+pip install "mmcls<0.23.1" "mmtrack<0.13.0"
 
 # 安装 mmhuman3d
 


### PR DESCRIPTION
This PR updates compatible versions following [mmcls](https://github.com/open-mmlab/mmclassification/blob/313d35704f36fe8f754f8cd26d364969718e357c/docs/en/faq.md) and [mmtrack](https://github.com/open-mmlab/mmtracking/blob/c250394b8a9ca95dae2ad49efe2d92ae450f605a/docs/en/install.md) to avoid installation issues. 

To be more specific,  `pip install "mmcls<0.18.0" "mmtrack<0.9.0,>=0.8.0"` is not compatible with mmcv-full==1.5.3 which is installed via the default command.