### PR TITLE
[Fix] slice fix for HumanData

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,7 @@ jobs:
           conda install pytorch3d -c pytorch3d
       - name: Install MMCV
         run: |
-          pip install mmcv-full -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch}}/index.html
+          pip install "mmcv-full>=1.3.17,<=1.5.3" -f https://download.openmmlab.com/mmcv/dist/cpu/torch${{matrix.torch}}/index.html
           python -c 'import mmcv; print(mmcv.__version__)'
       - name: Install other dependencies
         run: pip install -r requirements.txt

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install pre-commit hook
         run: |
           sudo apt-add-repository ppa:brightbox/ruby-ng -y

--- a/mmhuman3d/data/data_structures/human_data.py
+++ b/mmhuman3d/data/data_structures/human_data.py
@@ -580,6 +580,9 @@ class HumanData(dict):
                     HumanData.__get_sliced_result__(
                         value, dim, slice_index)
                 ret_human_data[key] = sliced_value
+        # check keypoints compressed
+        if self.check_keypoints_compressed():
+            ret_human_data.compress_keypoints_by_mask()
         return ret_human_data
 
     def __get_slice_dim__(self) -> dict:
@@ -610,6 +613,8 @@ class HumanData(dict):
                             sub_value_len = len(value[sub_key])
                             if sub_value_len != self.__data_len__:
                                 ret_dict[key][sub_key] = None
+                            elif 'dim' in value:
+                                ret_dict[key][sub_key] = value['dim']
                             else:
                                 ret_dict[key][sub_key] = 0
                         except TypeError:

--- a/mmhuman3d/data/data_structures/human_data.py
+++ b/mmhuman3d/data/data_structures/human_data.py
@@ -611,10 +611,10 @@ class HumanData(dict):
                     for sub_key in value.keys():
                         try:
                             sub_value_len = len(value[sub_key])
+                            if 'dim' in value:
+                                ret_dict[key][sub_key] = value['dim']
                             if sub_value_len != self.__data_len__:
                                 ret_dict[key][sub_key] = None
-                            elif 'dim' in value:
-                                ret_dict[key][sub_key] = value['dim']
                             else:
                                 ret_dict[key][sub_key] = 0
                         except TypeError:

--- a/mmhuman3d/data/data_structures/human_data.py
+++ b/mmhuman3d/data/data_structures/human_data.py
@@ -613,7 +613,7 @@ class HumanData(dict):
                             sub_value_len = len(value[sub_key])
                             if 'dim' in value:
                                 ret_dict[key][sub_key] = value['dim']
-                            if sub_value_len != self.__data_len__:
+                            elif sub_value_len != self.__data_len__:
                                 ret_dict[key][sub_key] = None
                             else:
                                 ret_dict[key][sub_key] = 0

--- a/tests/test_human_data.py
+++ b/tests/test_human_data.py
@@ -55,12 +55,6 @@ def test_set():
     with pytest.raises(ValueError):
         human_data = HumanData()
         human_data['bbox_xywh'] = np.zeros(shape=[2, 4])
-    # test wrong value with no shape attr
-    with pytest.raises(AttributeError):
-        human_data = HumanData()
-        bbox_np = np.zeros(shape=[2, 4])
-        delattr(bbox_np, 'shape')
-        human_data['bbox_xywh'] = bbox_np
     # test wrong value shape dim
     with pytest.raises(ValueError):
         human_data = HumanData()


### PR DESCRIPTION
This PR fixes some bugs for HumanData
1. Add keypoint compressed check for `get_slice`.
2. In the  `__get_slice_dim__`, if `dim` is in `self[key]`, the slice dim will be `value['dim']`.
3. Remove unused unit test.