### PR TITLE
fix expose config for inference

### DIFF
--- a/configs/expose/expose.py
+++ b/configs/expose/expose.py
@@ -1,6 +1,8 @@
 _base_ = ['../_base_/default_runtime.py']
 use_adversarial_train = True
 
+img_res = 256
+
 # evaluate
 evaluation = dict(
     interval=10,
@@ -105,7 +107,7 @@ extra_hand_model_cfg = dict(
             checkpoint='data/pretrained_models/resnet18_hmr_expose_hand.pth',
             prefix='head')),
     crop_cfg=dict(
-        img_res=256,
+        img_res=img_res,
         scale_factor=3.0,
         crop_size=224,
         condition_hand_wrist_pose=True,
@@ -150,7 +152,7 @@ extra_face_model_cfg = dict(
             prefix='head'),
     ),
     crop_cfg=dict(
-        img_res=256,
+        img_res=img_res,
         scale_factor=2.0,
         crop_size=256,
         num_betas=10,
@@ -280,7 +282,7 @@ train_pipeline = [
         scale_factor=0.25,
         rot_prob=0.6),
     dict(type='Rotation'),
-    dict(type='MeshAffine', img_res=256),  # hand = 224, body = head = 256
+    dict(type='MeshAffine', img_res=img_res),  # hand = 224, body = head = 256
     dict(type='RandomChannelNoise', noise_factor=0.4),
     dict(
         type='SimulateLowRes',
@@ -305,7 +307,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
-    dict(type='MeshAffine', img_res=256),
+    dict(type='MeshAffine', img_res=img_res),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img', 'ori_img']),
     dict(type='ToTensor', keys=data_keys),
@@ -318,15 +320,13 @@ test_pipeline = [
         ])
 ]
 inference_pipeline = [
-    dict(type='LoadImageFromFile'),
     dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
-    dict(type='MeshAffine', img_res=256),
+    dict(type='MeshAffine', img_res=img_res),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img', 'ori_img']),
-    dict(type='ToTensor', keys=data_keys),
     dict(
         type='Collect',
-        keys=['img', *data_keys],
+        keys=['img', 'sample_idx'],
         meta_keys=[
             'image_path', 'center', 'scale', 'rotation', 'ori_img',
             'crop_transform'

--- a/configs/expose/hrnet_hmr_expose_body.py
+++ b/configs/expose/hrnet_hmr_expose_body.py
@@ -1,6 +1,8 @@
 _base_ = ['../_base_/default_runtime.py']
 use_adversarial_train = True
 
+img_res = 256
+
 # evaluate
 evaluation = dict(interval=10, metric=['pa-mpjpe', 'mpjpe'])
 
@@ -172,7 +174,7 @@ train_pipeline = [
         rot_factor=30.0,
         scale_factor=0.25,
         rot_prob=0.6),
-    dict(type='MeshAffine', img_res=256),  # hand = 224, body = head = 256
+    dict(type='MeshAffine', img_res=img_res),  # hand = 224, body = head = 256
     dict(type='RandomChannelNoise', noise_factor=0.4),
     dict(
         type='SimulateLowRes',
@@ -194,7 +196,7 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
-    dict(type='MeshAffine', img_res=256),
+    dict(type='MeshAffine', img_res=img_res),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),
     dict(type='ToTensor', keys=data_keys),
@@ -204,15 +206,13 @@ test_pipeline = [
         meta_keys=['image_path', 'center', 'scale', 'rotation'])
 ]
 inference_pipeline = [
-    dict(type='LoadImageFromFile'),
     dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
-    dict(type='MeshAffine', img_res=256),
+    dict(type='MeshAffine', img_res=img_res),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),
-    dict(type='ToTensor', keys=data_keys),
     dict(
         type='Collect',
-        keys=['img', *data_keys],
+        keys=['img', 'sample_idx'],
         meta_keys=['image_path', 'center', 'scale', 'rotation'])
 ]
 

--- a/configs/expose/resnet18_hmr_expose_face.py
+++ b/configs/expose/resnet18_hmr_expose_face.py
@@ -1,6 +1,8 @@
 _base_ = ['../_base_/default_runtime.py']
 use_adversarial_train = True
 
+img_res = 256
+
 # evaluate
 evaluation = dict(interval=10, metric=['3DRMSE'])
 
@@ -104,7 +106,7 @@ train_pipeline = [
         rot_factor=30.0,
         scale_factor=0.2,
         rot_prob=0.6),
-    dict(type='MeshAffine', img_res=256),  # hand = 224, body = head = 256
+    dict(type='MeshAffine', img_res=img_res),  # hand = 224, body = head = 256
     dict(type='RandomChannelNoise', noise_factor=0.4),
     dict(
         type='SimulateLowRes',
@@ -126,13 +128,23 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
-    dict(type='MeshAffine', img_res=256),
+    dict(type='MeshAffine', img_res=img_res),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),
     dict(type='ToTensor', keys=data_keys),
     dict(
         type='Collect',
         keys=['img', *data_keys],
+        meta_keys=['image_path', 'center', 'scale', 'rotation'])
+]
+inference_pipeline = [
+    dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
+    dict(type='MeshAffine', img_res=img_res),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='ImageToTensor', keys=['img']),
+    dict(
+        type='Collect',
+        keys=['img', 'sample_idx'],
         meta_keys=['image_path', 'center', 'scale', 'rotation'])
 ]
 cache_files = {

--- a/configs/expose/resnet18_hmr_expose_hand.py
+++ b/configs/expose/resnet18_hmr_expose_hand.py
@@ -1,6 +1,8 @@
 _base_ = ['../_base_/default_runtime.py']
 use_adversarial_train = True
 
+img_res = 224
+
 # evaluate
 evaluation = dict(interval=10, metric=['pa-mpjpe', 'pa-pve'])
 
@@ -102,7 +104,7 @@ train_pipeline = [
         rot_factor=30.0,
         scale_factor=0.2,
         rot_prob=0.6),
-    dict(type='MeshAffine', img_res=224),  # hand = 224, body = head = 256
+    dict(type='MeshAffine', img_res=img_res),  # hand = 224, body = head = 256
     dict(type='RandomChannelNoise', noise_factor=0.4),
     dict(
         type='SimulateLowRes',
@@ -124,13 +126,23 @@ train_pipeline = [
 test_pipeline = [
     dict(type='LoadImageFromFile'),
     dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
-    dict(type='MeshAffine', img_res=224),
+    dict(type='MeshAffine', img_res=img_res),
     dict(type='Normalize', **img_norm_cfg),
     dict(type='ImageToTensor', keys=['img']),
     dict(type='ToTensor', keys=data_keys),
     dict(
         type='Collect',
         keys=['img', *data_keys],
+        meta_keys=['image_path', 'center', 'scale', 'rotation'])
+]
+inference_pipeline = [
+    dict(type='GetRandomScaleRotation', rot_factor=0, scale_factor=0),
+    dict(type='MeshAffine', img_res=img_res),
+    dict(type='Normalize', **img_norm_cfg),
+    dict(type='ImageToTensor', keys=['img']),
+    dict(
+        type='Collect',
+        keys=['img', 'sample_idx'],
         meta_keys=['image_path', 'center', 'scale', 'rotation'])
 ]
 cache_files = {


### PR DESCRIPTION
Expose inference pipeline can't work well for single-view image input. So I fix or add inference-pipeline for all four config files, and these can run correctly in my local environment.