### PR TITLE
Fix for expose inference

### DIFF
--- a/mmhuman3d/apis/inference.py
+++ b/mmhuman3d/apis/inference.py
@@ -415,7 +415,7 @@ def feature_extract(
 def _indexing_sequence(
         input: Union[Sequence, Dict[str, Sequence]],
         index: Union[int, Tuple[int, ...]]):
-    """Get item of the specified index from input
+    """Get item of the specified index from input.
 
     Args:
         input (Union[Sequence, Dict[str, Sequence]]): The input sequence.

--- a/mmhuman3d/apis/inference.py
+++ b/mmhuman3d/apis/inference.py
@@ -1,11 +1,11 @@
-from typing import Union, Dict, Tuple
 import cv2
 import mmcv
 import numpy as np
 import torch
-from mmcv.utils import print_log
 from mmcv.parallel import collate
 from mmcv.runner import load_checkpoint
+from mmcv.utils import print_log
+from typing import Dict, Tuple, Union
 
 from mmhuman3d.data.datasets.pipelines import Compose
 from mmhuman3d.models.architectures.builder import build_architecture

--- a/mmhuman3d/apis/inference.py
+++ b/mmhuman3d/apis/inference.py
@@ -3,6 +3,7 @@ import cv2
 import mmcv
 import numpy as np
 import torch
+from mmcv.utils import print_log
 from mmcv.parallel import collate
 from mmcv.runner import load_checkpoint
 
@@ -37,7 +38,10 @@ def init_model(config, checkpoint=None, device='cuda:0'):
 
     model = build_architecture(config.model)
     if checkpoint is None:
-        model.init_weights()
+        try:
+            model.init_weights()
+        except Exception as e:
+            print_log(f'init model weights failed, please check: {e}')
     if checkpoint is not None:
         # load model checkpoint
         load_checkpoint(model, checkpoint, map_location=device)
@@ -409,14 +413,14 @@ def feature_extract(
 
 
 def _indexing_sequence(
-    input: Union[Sequence, Dict[str, Sequence]],
-    index: Union[int, Tuple[int, ...]]) -> Union[Sequence, Dict[str, Sequence]]:
+        input: Union[Sequence, Dict[str, Sequence]],
+        index: Union[int, Tuple[int, ...]]):
     """Get item of the specified index from input
 
     Args:
         input (Union[Sequence, Dict[str, Sequence]]): The input sequence.
         index (Union[int, Tuple[int, ...]]): The Specified index.
-    
+
     Returns:
         Union[Sequence, Dict[str, Sequence]]: The item of specified index.
     """

--- a/mmhuman3d/apis/inference.py
+++ b/mmhuman3d/apis/inference.py
@@ -12,7 +12,6 @@ from mmhuman3d.models.architectures.builder import build_architecture
 from mmhuman3d.models.backbones.builder import build_backbone
 from mmhuman3d.utils.demo_utils import box2cs, xywh2xyxy, xyxy2xywh
 
-
 Sequence = Union[np.ndarray, torch.Tensor, list, tuple]
 
 
@@ -204,8 +203,7 @@ def inference_image_based_model(
         mesh_result = det_results[idx].copy()
         mesh_result['bbox'] = bboxes_xyxy[idx]
         for key, value in results.items():
-            mesh_result[key] = _indexing_sequence(
-                value, index=idx)
+            mesh_result[key] = _indexing_sequence(value, index=idx)
         mesh_results.append(mesh_result)
     return mesh_results
 
@@ -412,9 +410,8 @@ def feature_extract(
     return feature_results
 
 
-def _indexing_sequence(
-        input: Union[Sequence, Dict[str, Sequence]],
-        index: Union[int, Tuple[int, ...]]):
+def _indexing_sequence(input: Union[Sequence, Dict[str, Sequence]],
+                       index: Union[int, Tuple[int, ...]]):
     """Get item of the specified index from input.
 
     Args:

--- a/mmhuman3d/apis/inference.py
+++ b/mmhuman3d/apis/inference.py
@@ -1,3 +1,5 @@
+from typing import Dict, Tuple, Union
+
 import cv2
 import mmcv
 import numpy as np
@@ -5,7 +7,6 @@ import torch
 from mmcv.parallel import collate
 from mmcv.runner import load_checkpoint
 from mmcv.utils import print_log
-from typing import Dict, Tuple, Union
 
 from mmhuman3d.data.datasets.pipelines import Compose
 from mmhuman3d.models.architectures.builder import build_architecture

--- a/mmhuman3d/apis/inference.py
+++ b/mmhuman3d/apis/inference.py
@@ -36,7 +36,8 @@ def init_model(config, checkpoint=None, device='cuda:0'):
     config.data.test.test_mode = True
 
     model = build_architecture(config.model)
-    model.init_weights()
+    if checkpoint is None:
+        model.init_weights()
     if checkpoint is not None:
         # load model checkpoint
         load_checkpoint(model, checkpoint, map_location=device)


### PR DESCRIPTION
In expose model config, we specify pretrained model path in `init_cfg` parameter. It means we don't need to specify checkpoint when call `init_model`, but we need to call `model.init_weights()` the load the pretrained model in `init_cfg`, otherwise the model will not load pretrained weights in `init_cfg`.

The origin `inference_image_based_model` only returns value of specified keys, like `smpl_pose`, `smpl_beta` etc. However, the expose model will return more parameters which we may want to use, so I think it is better to return all model outputs and it is up to user to decide which to use. 😄 