### PR TITLE
[Upgrade] Specify the numpy version less than 1.24.

### DIFF
--- a/configs/gta_human/README.md
+++ b/configs/gta_human/README.md
@@ -66,7 +66,7 @@ Please refer to [getting_started.md](../../docs/getting_started.md) for training
 
 ## Visualization
 
-We prepared a script with a sample sequence that should help you with the SMPL overlay. 
+We prepared a script with a sample sequence that should help you with the SMPL overlay.
 You may download it from [here](https://drive.google.com/file/d/11osPM67KiQN6NbdJo3plcgNoPNxfJ_j7/view?usp=share_link).
 
 ## Notes

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,7 +6,7 @@ easydev
 einops
 h5py
 matplotlib
-numpy==1.23.1
+numpy<=1.23
 opencv-python
 pandas<2.0.0
 pickle5

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,7 +6,7 @@ easydev
 einops
 h5py
 matplotlib
-numpy
+numpy==1.23.1
 opencv-python
 pandas<2.0.0
 pickle5

--- a/requirements/runtime.txt
+++ b/requirements/runtime.txt
@@ -6,7 +6,7 @@ easydev
 einops
 h5py
 matplotlib
-numpy<=1.23
+numpy<1.24
 opencv-python
 pandas<2.0.0
 pickle5


### PR DESCRIPTION
Since numpy v1.24.0 removed `np.object, np.bool, np.float, np.complex, np.str, and np.int`, which are used in chumpy v0.70, we specify a numpy version less than 1.24.